### PR TITLE
Activate non-prod DB migrations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ ansiColor('xterm') {
         stage('Run Migrations') {
           build job: "Migrations/dev-migrations/dev-collections-service-postgres-migrations",
                   parameters: [
-                          string(name: 'IMAGE_TAG', value: 'describe3')
+                          string(name: 'IMAGE_TAG', value: imageTag)
                   ]
         }
 


### PR DESCRIPTION
Now that Terraform has created the SSM parameters needed by dbmigrate (via cloudwrap), we can run Postgres migrations in non-prod.