### PR TITLE
Fix:  dbmigrate cannot use RDS Proxy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ ansiColor('xterm') {
         stage('Run Migrations') {
           build job: "Migrations/dev-migrations/dev-collections-service-postgres-migrations",
                   parameters: [
-                          string(name: 'IMAGE_TAG', value: imageTag)
+                          string(name: 'IMAGE_TAG', value: 'describe4')
                   ]
         }
 

--- a/cmd/dbmigrate/main.go
+++ b/cmd/dbmigrate/main.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	awsCfg "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/pennsieve/collections-service/internal/dbmigrate"
 	"log/slog"
 	"os"
@@ -18,17 +16,20 @@ func main() {
 		logger.Error("error loading config", slog.Any("error", err))
 		os.Exit(1)
 	}
+	if migrateConfig.PostgresDB.Password == nil {
+		logger.Error("password must be specified; cannot currently use RDS proxy for migrates since no Postgres role with the appropriate grants has credentials in the proxy")
+		os.Exit(1)
+	}
 	logger.
 		With(slog.Bool("verboseLogging", migrateConfig.VerboseLogging),
 			slog.Group("postgres",
 				slog.String("host", migrateConfig.PostgresDB.Host),
 				slog.Int("port", migrateConfig.PostgresDB.Port),
 				slog.String("username", migrateConfig.PostgresDB.User),
-				slog.Bool("useRDSProxy", migrateConfig.PostgresDB.Password == nil),
 				slog.String("database", migrateConfig.PostgresDB.CollectionsDatabase),
 			)).
 		Info("collections DB schema migration started")
-	m, err := newCollectionsManager(ctx, migrateConfig)
+	m, err := dbmigrate.NewLocalCollectionsMigrator(ctx, migrateConfig)
 	if err != nil {
 		logger.Error("error creating CollectionsMigrator", slog.Any("error", err))
 		os.Exit(1)
@@ -41,15 +42,4 @@ func main() {
 	}
 
 	logger.Info("collections DB schema migration complete")
-}
-
-func newCollectionsManager(ctx context.Context, migrateConfig dbmigrate.Config) (*dbmigrate.CollectionsMigrator, error) {
-	if migrateConfig.PostgresDB.Password == nil {
-		awsConfig, err := awsCfg.LoadDefaultConfig(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("error loading AWS config: %w", err)
-		}
-		return dbmigrate.NewRDSProxyCollectionsMigrator(ctx, migrateConfig, awsConfig)
-	}
-	return dbmigrate.NewLocalCollectionsMigrator(ctx, migrateConfig)
 }

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -2,13 +2,23 @@
 resource "aws_ssm_parameter" "postgres_host" {
   name  = "/${var.environment_name}/${var.dbmigrate_service_name}/postgres-host"
   type  = "String"
-  value = data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint
+  value = data.terraform_remote_state.pennsieve_postgres.outputs.master_fqdn
 }
 
 resource "aws_ssm_parameter" "postgres_user" {
   name  = "/${var.environment_name}/${var.dbmigrate_service_name}/postgres-user"
   type  = "String"
   value = var.dbmigrate_postgres_user
+}
+
+resource "aws_ssm_parameter" "postgres_password" {
+  name  = "/${var.environment_name}/${var.dbmigrate_service_name}/postgres-password"
+  type  = "SecureString"
+  value = "dummy"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
 }
 
 resource "aws_ssm_parameter" "postgres_collections_database" {


### PR DESCRIPTION
The user dbmigrate needs to use is not configured to be used with the RDS Proxy, so PR updates the SSM store with the non-proxy DB host, and a variable for the DB user's password.