### PR TITLE
Fix for paths

### DIFF
--- a/terraform/collections-service.yml
+++ b/terraform/collections-service.yml
@@ -12,9 +12,9 @@ info:
     name: Apache 2.0
     url: https://www.apache.org/licenses/LICENSE-2.0.html
 servers:
-  - url: https://api2.pennsieve.io
+  - url: https://api2.pennsieve.io/collections
     description: Production server
-  - url: https://api2.pennsieve.net
+  - url: https://api2.pennsieve.net/collections
     description: Development server
 externalDocs:
   description: Find more info here
@@ -26,7 +26,7 @@ tags:
       url: https://docs.pennsieve.io/reference
 
 paths:
-  /collections:
+  /:
     get:
       x-amazon-apigateway-integration:
         $ref: '#/components/x-amazon-apigateway-integrations/collections-service'
@@ -83,7 +83,7 @@ paths:
         - Collections Service
       responses:
         '201':
-          description: the created collection
+          description: collection created
           content:
             application/json:
               schema:


### PR DESCRIPTION
When the OpenAPI spec has 
```
servers:
  - url: https://api2.pennsieve.io
    description: Production server
  - url: https://api2.pennsieve.net
    description: Development server
...
paths:
  /collections:
```

we end up with endpoints at `https://api2.pennsieve.net/collections/collections` instead of the desired `https://api2.pennsieve.net/collections`

This is because of the AWS settings in `gateway.tf`
```
resource "aws_apigatewayv2_api_mapping" "collections_service_api_map" {
  api_id          = aws_apigatewayv2_api.collections_service_api.id
  domain_name     = var.api_domain_name
  stage           = aws_apigatewayv2_stage.collections_service_gateway_stage.id
  api_mapping_key = "collections"
}
```
where `var.api_domain_name` is https://api2.pennsieve.net in non-prod. It looks like AWS adds the `api_mapping_key` to the URL. We cannot remove the mapping key for this service because the original api2 services are already mapped to this domain with the empty string.


This PR changes the OpenAPI spec to
```
servers:
  - url: https://api2.pennsieve.io/collections
    description: Production server
  - url: https://api2.pennsieve.net/collections
    description: Development server
...
paths:
  /:
```

instead. I've already seen that this results in the readme.com docs showing the URL for GET and POST ops as
`https://api2.pennsieve.net/collections/` with an unwelcome trailing slash. I'm not sure how API Gateway will react,  so this PR is a test of that.
