### PR TITLE
Fix routeKeys

### DIFF
--- a/internal/api/dto/collection.go
+++ b/internal/api/dto/collection.go
@@ -2,14 +2,14 @@ package dto
 
 import "time"
 
-// CreateCollectionRequest represents the request body of POST /collections
+// CreateCollectionRequest represents the request body of POST /
 type CreateCollectionRequest struct {
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	DOIs        []string `json:"dois"`
 }
 
-// GetCollectionsResponse represents the response body of GET /collections
+// GetCollectionsResponse represents the response body of GET /
 type GetCollectionsResponse struct {
 	Limit       int                  `json:"limit"`
 	Offset      int                  `json:"offset"`
@@ -17,14 +17,14 @@ type GetCollectionsResponse struct {
 	Collections []CollectionResponse `json:"collections"`
 }
 
-// GetCollectionResponse represents the response body of GET /collections/{id}
+// GetCollectionResponse represents the response body of GET //{id}
 type GetCollectionResponse struct {
 	CollectionResponse
 	Contributors []string        `json:"contributors"`
 	Datasets     []PublicDataset `json:"datasets"`
 }
 
-// CollectionResponse is a base struct shared by GET /collections and GET /collections/{id}
+// CollectionResponse is a base struct shared by GET / and GET //{id}
 type CollectionResponse struct {
 	NodeID      string   `json:"nodeId"`
 	Name        string   `json:"name"`

--- a/internal/api/dto/collection.go
+++ b/internal/api/dto/collection.go
@@ -17,14 +17,14 @@ type GetCollectionsResponse struct {
 	Collections []CollectionResponse `json:"collections"`
 }
 
-// GetCollectionResponse represents the response body of GET //{id}
+// GetCollectionResponse represents the response body of GET /{nodeId}
 type GetCollectionResponse struct {
 	CollectionResponse
 	Contributors []string        `json:"contributors"`
 	Datasets     []PublicDataset `json:"datasets"`
 }
 
-// CollectionResponse is a base struct shared by GET / and GET //{id}
+// CollectionResponse is a base struct shared by GET / and GET /{nodeId}
 type CollectionResponse struct {
 	NodeID      string   `json:"nodeId"`
 	Name        string   `json:"name"`

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -63,9 +63,9 @@ func CollectionsServiceAPIHandler(
 			Claims:    claims,
 		}
 		switch routeKey {
-		case "POST /collections":
+		case routes.CreateCollectionRouteKey:
 			return routes.Handle(ctx, routes.NewCreateCollectionRouteHandler(), routeParams)
-		case "GET /collections":
+		case routes.GetCollectionsRouteKey:
 			return routes.Handle(ctx, routes.NewGetCollectionsRouteHandler(), routeParams)
 		default:
 			routeNotFound := apierrors.NewError(fmt.Sprintf("route [%s] not found", routeKey), nil, http.StatusNotFound)

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -58,7 +58,7 @@ func testDefaultNotFound(t *testing.T) {
 func testNoClaims(t *testing.T) {
 	handler := CollectionsServiceAPIHandler(apitest.NewTestContainer(), apitest.NewConfigBuilder().Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").Build()
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).Build()
 
 	response, err := handler(context.Background(), req)
 
@@ -79,7 +79,7 @@ func testCreateCollectionExternalDOIs(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -105,7 +105,7 @@ func testCreateCollectionEmptyName(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -129,7 +129,7 @@ func testCreateCollectionNameTooLong(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -153,7 +153,7 @@ func testCreateCollectionDescriptionTooLong(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -191,7 +191,7 @@ func testCreateCollectionUnpublishedDOIs(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -211,7 +211,7 @@ func testCreateCollectionNoBody(t *testing.T) {
 		apitest.NewTestContainer(),
 		apitest.NewConfigBuilder().Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").WithDefaultClaims(apitest.User).Build()
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).WithDefaultClaims(apitest.User).Build()
 
 	response, err := handler(context.Background(), req)
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func testCreateCollectionMalformedBody(t *testing.T) {
 		apitest.NewTestContainer(),
 		apitest.NewConfigBuilder().Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(apitest.User).
 		Build()
 
@@ -288,7 +288,7 @@ func testCreateCollection(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.CreateCollectionRouteKey).
 		WithDefaultClaims(callingUser).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -355,7 +355,7 @@ func testGetCollections(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build(),
 	)
-	req := apitest.NewAPIGatewayRequestBuilder("GET /").
+	req := apitest.NewAPIGatewayRequestBuilder(routes.GetCollectionsRouteKey).
 		WithDefaultClaims(callingUser).
 		WithIntQueryParam("offset", expectedOffset).
 		Build()

--- a/internal/api/handler_test.go
+++ b/internal/api/handler_test.go
@@ -58,7 +58,7 @@ func testDefaultNotFound(t *testing.T) {
 func testNoClaims(t *testing.T) {
 	handler := CollectionsServiceAPIHandler(apitest.NewTestContainer(), apitest.NewConfigBuilder().Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").Build()
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").Build()
 
 	response, err := handler(context.Background(), req)
 
@@ -79,7 +79,7 @@ func testCreateCollectionExternalDOIs(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -105,7 +105,7 @@ func testCreateCollectionEmptyName(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -129,7 +129,7 @@ func testCreateCollectionNameTooLong(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -153,7 +153,7 @@ func testCreateCollectionDescriptionTooLong(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -191,7 +191,7 @@ func testCreateCollectionUnpublishedDOIs(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(apitest.User).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -211,7 +211,7 @@ func testCreateCollectionNoBody(t *testing.T) {
 		apitest.NewTestContainer(),
 		apitest.NewConfigBuilder().Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").WithDefaultClaims(apitest.User).Build()
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").WithDefaultClaims(apitest.User).Build()
 
 	response, err := handler(context.Background(), req)
 	require.NoError(t, err)
@@ -226,7 +226,7 @@ func testCreateCollectionMalformedBody(t *testing.T) {
 		apitest.NewTestContainer(),
 		apitest.NewConfigBuilder().Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(apitest.User).
 		Build()
 
@@ -288,7 +288,7 @@ func testCreateCollection(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build())
 
-	req := apitest.NewAPIGatewayRequestBuilder("POST /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("POST /").
 		WithDefaultClaims(callingUser).
 		WithBody(t, createCollectionRequest).
 		Build()
@@ -355,7 +355,7 @@ func testGetCollections(t *testing.T) {
 			WithPennsieveConfig(apitest.PennsieveConfigWithFakeURL()).
 			Build(),
 	)
-	req := apitest.NewAPIGatewayRequestBuilder("GET /collections").
+	req := apitest.NewAPIGatewayRequestBuilder("GET /").
 		WithDefaultClaims(callingUser).
 		WithIntQueryParam("offset", expectedOffset).
 		Build()

--- a/internal/api/routes/create_collection.go
+++ b/internal/api/routes/create_collection.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 )
 
+const CreateCollectionRouteKey = "POST /"
+
 func CreateCollection(ctx context.Context, params Params) (dto.CollectionResponse, error) {
 	if len(params.Request.Body) == 0 {
 		return dto.CollectionResponse{}, apierrors.NewBadRequestError("no request body")

--- a/internal/api/routes/create_collection_test.go
+++ b/internal/api/routes/create_collection_test.go
@@ -73,7 +73,7 @@ func testCreateCollectionNoDTOs(t *testing.T, expectationDB *fixtures.Expectatio
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),
@@ -139,7 +139,7 @@ func testCreateCollectionTwoDTOs(t *testing.T, expectationDB *fixtures.Expectati
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),
@@ -219,7 +219,7 @@ func testCreateCollectionFiveDTOs(t *testing.T, expectationDB *fixtures.Expectat
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),
@@ -300,7 +300,7 @@ func testCreateCollectionSomeMissingBanners(t *testing.T, expectationDB *fixture
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),

--- a/internal/api/routes/create_collection_test.go
+++ b/internal/api/routes/create_collection_test.go
@@ -73,7 +73,7 @@ func testCreateCollectionNoDTOs(t *testing.T, expectationDB *fixtures.Expectatio
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
+		Request: apitest.NewAPIGatewayRequestBuilder(CreateCollectionRouteKey).
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),
@@ -139,7 +139,7 @@ func testCreateCollectionTwoDTOs(t *testing.T, expectationDB *fixtures.Expectati
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
+		Request: apitest.NewAPIGatewayRequestBuilder(CreateCollectionRouteKey).
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),
@@ -219,7 +219,7 @@ func testCreateCollectionFiveDTOs(t *testing.T, expectationDB *fixtures.Expectat
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
+		Request: apitest.NewAPIGatewayRequestBuilder(CreateCollectionRouteKey).
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),
@@ -300,7 +300,7 @@ func testCreateCollectionSomeMissingBanners(t *testing.T, expectationDB *fixture
 		WithContainerStoreFromPostgresDB(config.PostgresDB.CollectionsDatabase)
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("POST /").
+		Request: apitest.NewAPIGatewayRequestBuilder(CreateCollectionRouteKey).
 			WithClaims(claims).
 			WithBody(t, createCollectionRequest).
 			Build(),

--- a/internal/api/routes/get_collection.go
+++ b/internal/api/routes/get_collection.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 )
 
+const GetCollectionRouteKey = "GET /{nodeId}"
+
 func GetCollection(ctx context.Context, params Params) (dto.GetCollectionResponse, error) {
 	nodeID := params.Request.PathParameters["nodeId"]
 	if len(nodeID) == 0 {

--- a/internal/api/routes/get_collections.go
+++ b/internal/api/routes/get_collections.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 )
 
+const GetCollectionsRouteKey = "GET /"
+
 const DefaultGetCollectionsLimit = 10
 const DefaultGetCollectionsOffset = 0
 

--- a/internal/api/routes/get_collections_test.go
+++ b/internal/api/routes/get_collections_test.go
@@ -78,7 +78,7 @@ func testGetCollectionsNone(t *testing.T, expectationDB *fixtures.ExpectationDB)
 	limit, offset := 100, 10
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
+		Request: apitest.NewAPIGatewayRequestBuilder(GetCollectionsRouteKey).
 			WithClaims(claims).
 			WithIntQueryParam("limit", limit).
 			WithIntQueryParam("offset", offset).
@@ -139,7 +139,7 @@ func testGetCollections(t *testing.T, expectationDB *fixtures.ExpectationDB) {
 		WithHTTPTestDiscover(mockDiscoverServer.URL)
 
 	user1Params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
+		Request: apitest.NewAPIGatewayRequestBuilder(GetCollectionsRouteKey).
 			WithClaims(user1Claims).
 			Build(),
 		Container: container,
@@ -169,7 +169,7 @@ func testGetCollections(t *testing.T, expectationDB *fixtures.ExpectationDB) {
 	// try user2's collections
 	user2Claims := apitest.DefaultClaims(user2)
 	user2Params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
+		Request: apitest.NewAPIGatewayRequestBuilder(GetCollectionsRouteKey).
 			WithClaims(user2Claims).
 			Build(),
 		Container: container,
@@ -220,7 +220,7 @@ func testGetCollectionsLimitOffset(t *testing.T, expectationDB *fixtures.Expecta
 
 	for ; offset < totalCollections; offset += limit {
 		params := Params{
-			Request: apitest.NewAPIGatewayRequestBuilder("GET /").
+			Request: apitest.NewAPIGatewayRequestBuilder(GetCollectionsRouteKey).
 				WithClaims(userClaims).
 				WithIntQueryParam("limit", limit).
 				WithIntQueryParam("offset", offset).
@@ -247,7 +247,7 @@ func testGetCollectionsLimitOffset(t *testing.T, expectationDB *fixtures.Expecta
 	// now offset >= totalCollections, so the response should have no collections
 	// but still have the correct TotalCount.
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
+		Request: apitest.NewAPIGatewayRequestBuilder(GetCollectionsRouteKey).
 			WithClaims(userClaims).
 			WithIntQueryParam("limit", limit).
 			WithIntQueryParam("offset", offset).

--- a/internal/api/routes/get_collections_test.go
+++ b/internal/api/routes/get_collections_test.go
@@ -78,7 +78,7 @@ func testGetCollectionsNone(t *testing.T, expectationDB *fixtures.ExpectationDB)
 	limit, offset := 100, 10
 
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
 			WithClaims(claims).
 			WithIntQueryParam("limit", limit).
 			WithIntQueryParam("offset", offset).
@@ -139,7 +139,7 @@ func testGetCollections(t *testing.T, expectationDB *fixtures.ExpectationDB) {
 		WithHTTPTestDiscover(mockDiscoverServer.URL)
 
 	user1Params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
 			WithClaims(user1Claims).
 			Build(),
 		Container: container,
@@ -169,7 +169,7 @@ func testGetCollections(t *testing.T, expectationDB *fixtures.ExpectationDB) {
 	// try user2's collections
 	user2Claims := apitest.DefaultClaims(user2)
 	user2Params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
 			WithClaims(user2Claims).
 			Build(),
 		Container: container,
@@ -220,7 +220,7 @@ func testGetCollectionsLimitOffset(t *testing.T, expectationDB *fixtures.Expecta
 
 	for ; offset < totalCollections; offset += limit {
 		params := Params{
-			Request: apitest.NewAPIGatewayRequestBuilder("GET /collections").
+			Request: apitest.NewAPIGatewayRequestBuilder("GET /").
 				WithClaims(userClaims).
 				WithIntQueryParam("limit", limit).
 				WithIntQueryParam("offset", offset).
@@ -247,7 +247,7 @@ func testGetCollectionsLimitOffset(t *testing.T, expectationDB *fixtures.Expecta
 	// now offset >= totalCollections, so the response should have no collections
 	// but still have the correct TotalCount.
 	params := Params{
-		Request: apitest.NewAPIGatewayRequestBuilder("GET /collections").
+		Request: apitest.NewAPIGatewayRequestBuilder("GET /").
 			WithClaims(userClaims).
 			WithIntQueryParam("limit", limit).
 			WithIntQueryParam("offset", offset).


### PR DESCRIPTION
Because of the way the API Gateway for this service is currently configured the routeKeys all need to look like `METHOD /...` instead of `METHOD /collections...` for now. 

This may change in the future, so PR also creates constants for these routeKey strings.