### PR TITLE
Fix: Return empty arrays instead of null

### DIFF
--- a/internal/api/routes/create_collection.go
+++ b/internal/api/routes/create_collection.go
@@ -14,29 +14,29 @@ import (
 
 const CreateCollectionRouteKey = "POST /"
 
-func CreateCollection(ctx context.Context, params Params) (dto.CollectionResponse, error) {
+func CreateCollection(ctx context.Context, params Params) (dto.CreateCollectionResponse, error) {
 	if len(params.Request.Body) == 0 {
-		return dto.CollectionResponse{}, apierrors.NewBadRequestError("no request body")
+		return dto.CreateCollectionResponse{}, apierrors.NewBadRequestError("no request body")
 	}
 	var createRequest dto.CreateCollectionRequest
 	if err := json.Unmarshal([]byte(params.Request.Body), &createRequest); err != nil {
-		return dto.CollectionResponse{}, apierrors.NewRequestUnmarshallError(createRequest, err)
+		return dto.CreateCollectionResponse{}, apierrors.NewRequestUnmarshallError(createRequest, err)
 	}
 	ccParams := createCollectionParams{Params: params}
 
 	if err := ccParams.ValidateCreateRequest(createRequest); err != nil {
-		return dto.CollectionResponse{}, err
+		return dto.CreateCollectionResponse{}, err
 	}
 
 	pennsieveDOIs, externalDOIs := CategorizeDOIs(ccParams.Config.PennsieveConfig.DOIPrefix, createRequest.DOIs)
 	if len(externalDOIs) > 0 {
 		// We may later allow non-Pennsieve DOIs, but for now, this is an error
-		return dto.CollectionResponse{}, apierrors.NewBadRequestError(
+		return dto.CreateCollectionResponse{}, apierrors.NewBadRequestError(
 			fmt.Sprintf("request contains non-Pennsieve DOIs: %s", strings.Join(externalDOIs, ", ")))
 	}
 
 	nodeID := uuid.NewString()
-	response := dto.CollectionResponse{
+	response := dto.CreateCollectionResponse{
 		NodeID:      nodeID,
 		Name:        createRequest.Name,
 		Description: createRequest.Description,
@@ -45,7 +45,7 @@ func CreateCollection(ctx context.Context, params Params) (dto.CollectionRespons
 	if len(pennsieveDOIs) > 0 {
 		datasetResults, err := ccParams.Container.Discover().GetDatasetsByDOI(pennsieveDOIs)
 		if err != nil {
-			return dto.CollectionResponse{}, apierrors.NewInternalServerError("error looking up DOIs in Discover", err)
+			return dto.CreateCollectionResponse{}, apierrors.NewInternalServerError("error looking up DOIs in Discover", err)
 		}
 
 		if len(datasetResults.Unpublished) > 0 {
@@ -53,7 +53,7 @@ func CreateCollection(ctx context.Context, params Params) (dto.CollectionRespons
 			for _, unpublished := range datasetResults.Unpublished {
 				details = append(details, fmt.Sprintf("%s status is %s", unpublished.DOI, unpublished.Status))
 			}
-			return dto.CollectionResponse{}, apierrors.NewBadRequestError(fmt.Sprintf("request contains unpublished DOIs: %s", strings.Join(details, ", ")))
+			return dto.CreateCollectionResponse{}, apierrors.NewBadRequestError(fmt.Sprintf("request contains unpublished DOIs: %s", strings.Join(details, ", ")))
 		}
 
 		response.Banners = collectBanners(createRequest.DOIs, datasetResults.Published)
@@ -63,8 +63,7 @@ func CreateCollection(ctx context.Context, params Params) (dto.CollectionRespons
 
 	storeResp, err := collectionsStore.CreateCollection(ctx, params.Claims.UserClaim.Id, nodeID, createRequest.Name, createRequest.Description, pennsieveDOIs)
 	if err != nil {
-		return dto.CollectionResponse{},
-			apierrors.NewInternalServerError(fmt.Sprintf("error creating collection %s", createRequest.Name), err)
+		return dto.CreateCollectionResponse{}, apierrors.NewInternalServerError(fmt.Sprintf("error creating collection %s", createRequest.Name), err)
 	}
 
 	response.UserRole = storeResp.CreatorRole.String()
@@ -72,8 +71,8 @@ func CreateCollection(ctx context.Context, params Params) (dto.CollectionRespons
 	return response, nil
 }
 
-func NewCreateCollectionRouteHandler() Handler[dto.CollectionResponse] {
-	return Handler[dto.CollectionResponse]{
+func NewCreateCollectionRouteHandler() Handler[dto.CreateCollectionResponse] {
+	return Handler[dto.CreateCollectionResponse]{
 		HandleFunc:        CreateCollection,
 		SuccessStatusCode: http.StatusCreated,
 		Headers:           DefaultResponseHeaders(),

--- a/internal/test/apitest/dtos.go
+++ b/internal/test/apitest/dtos.go
@@ -6,16 +6,26 @@ import (
 
 func NewPublicDataset(doi string, banner *string) dto.PublicDataset {
 	// as of now, other values here are not relevant to tests. Maybe add some later
+	// Slices are initialized empty so that they match objects that were marshalled and then unmarshalled
+	// in tests. (We marshal nil slices into "[]" rather than null.
 	return dto.PublicDataset{
-		DOI:    doi,
-		Banner: banner,
+		DOI:                  doi,
+		Banner:               banner,
+		Tags:                 make([]string, 0),
+		ModelCount:           make([]dto.ModelCount, 0),
+		Collections:          make([]dto.PublicCollection, 0),
+		Contributors:         make([]dto.PublicContributor, 0),
+		ExternalPublications: make([]dto.PublicExternalPublication, 0),
 	}
 }
 
 func NewTombstone(doi string, status string) dto.Tombstone {
 	// as of now, other values here are not relevant to tests. Maybe add some later
+	// Slices are initialized empty so that they match objects that were marshalled and then unmarshalled
+	// in tests. (We marshal nil slices into "[]" rather than null.
 	return dto.Tombstone{
 		Status: status,
 		DOI:    doi,
+		Tags:   make([]string, 0),
 	}
 }


### PR DESCRIPTION
PR updates the response DTOs which contain slices to implement `json.Marshaler` so that nil slices are changed to empty slices prior to serialization. Idea is to always return `"field":[]` instead of `"field":null` to our callers without having to always manually initialize all slices in the response.

It does mean that some helpers that create objects for tests have initialize the slices so that `assert.Equal` still works without extra handling.
