### PR TITLE
Fix: Prevent empty name and DOI

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,7 +24,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   pennsievedb-collections:
-    image: pennsieve/pennsievedb-collections:20250421162715-seed
+    image: pennsieve/pennsievedb-collections:20250422101951-seed
     restart: always
 #    command: [ "postgres", "-c", "log_statement=all" ]
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,7 +24,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   pennsievedb-collections:
-    image: pennsieve/pennsievedb-collections:20250327123104-seed
+    image: pennsieve/pennsievedb-collections:20250421162715-seed
     restart: always
 #    command: [ "postgres", "-c", "log_statement=all" ]
 

--- a/internal/api/routes/create_collection.go
+++ b/internal/api/routes/create_collection.go
@@ -56,7 +56,7 @@ func CreateCollection(ctx context.Context, params Params) (dto.CreateCollectionR
 			return dto.CreateCollectionResponse{}, apierrors.NewBadRequestError(fmt.Sprintf("request contains unpublished DOIs: %s", strings.Join(details, ", ")))
 		}
 
-		response.Banners = collectBanners(createRequest.DOIs, datasetResults.Published)
+		response.Banners = collectBanners(pennsieveDOIs, datasetResults.Published)
 
 	}
 	collectionsStore := ccParams.Container.CollectionsStore()

--- a/internal/api/routes/create_collection.go
+++ b/internal/api/routes/create_collection.go
@@ -24,7 +24,7 @@ func CreateCollection(ctx context.Context, params Params) (dto.CreateCollectionR
 	}
 	ccParams := createCollectionParams{Params: params}
 
-	if err := ccParams.ValidateCreateRequest(createRequest); err != nil {
+	if err := ccParams.ValidateCreateRequest(&createRequest); err != nil {
 		return dto.CreateCollectionResponse{}, err
 	}
 
@@ -83,7 +83,10 @@ type createCollectionParams struct {
 	Params
 }
 
-func (p createCollectionParams) ValidateCreateRequest(request dto.CreateCollectionRequest) *apierrors.Error {
+// ValidateCreateRequest may alter the passed in request by trimming whitespace from request.Name and request.Description.
+func (p createCollectionParams) ValidateCreateRequest(request *dto.CreateCollectionRequest) *apierrors.Error {
+	request.Name = strings.TrimSpace(request.Name)
+	request.Description = strings.TrimSpace(request.Description)
 	if err := validate.CollectionName(request.Name); err != nil {
 		return err
 	}

--- a/internal/api/routes/create_collection_test.go
+++ b/internal/api/routes/create_collection_test.go
@@ -334,11 +334,12 @@ func testCreateCollectionRemoveWhitespace(t *testing.T, expectationDB *fixtures.
 		WithUser(callingUser.ID, pgdb.Owner).
 		WithDOIs(publishedDOI1, publishedDOI2)
 
-	//Add some whitespace to name and description. Server should trim it off before creation.
+	// Add some whitespace to vales in the create request.
+	// Server should trim it off before creation and return the trimmed values.
 	createCollectionRequest := dto.CreateCollectionRequest{
 		Name:        fmt.Sprintf("   %s ", expectedCollection.Name),
 		Description: fmt.Sprintf("%s  ", expectedCollection.Description),
-		DOIs:        expectedCollection.DOIs.Strings(),
+		DOIs:        []string{fmt.Sprintf(" %s", publishedDOI1), fmt.Sprintf("%s ", publishedDOI2)},
 	}
 
 	mockDiscoverServer := httptest.NewServer(mocks.ToDiscoverHandlerFunc(t, func(dois []string) (service.DatasetsByDOIResponse, error) {

--- a/internal/api/routes/dois.go
+++ b/internal/api/routes/dois.go
@@ -13,6 +13,7 @@ func CategorizeDOIs(pennsieveDOIPrefix string, dois []string) (pennsieveDOIs []s
 	// Maybe overly complicated, but trying to maintain order of the dois so that
 	// if there are dups, we take the first one
 	for _, doi := range dois {
+		doi = strings.TrimSpace(doi)
 		if _, seen := seenDOIs[doi]; !seen {
 			seenDOIs[doi] = true
 			if strings.HasPrefix(doi, pennsievePrefixAndSlash) {

--- a/internal/api/routes/dois.go
+++ b/internal/api/routes/dois.go
@@ -6,7 +6,7 @@ import (
 )
 
 // CategorizeDOIs splits the given dois into either Pennsieve or non-Pennsieve, based on the prefix.
-// Also de-duplicates the DOIs.
+// Also de-duplicates the DOIs and trims any leading or trailing whitespace.
 func CategorizeDOIs(pennsieveDOIPrefix string, dois []string) (pennsieveDOIs []string, externalDOIs []string) {
 	pennsievePrefixAndSlash := fmt.Sprintf("%s/", pennsieveDOIPrefix)
 	seenDOIs := map[string]bool{}

--- a/internal/dbmigrate/migrate_test.go
+++ b/internal/dbmigrate/migrate_test.go
@@ -132,13 +132,14 @@ func testPreventEmptyName(t *testing.T, migrator *dbmigrate.CollectionsMigrator,
 
 	ctx := context.Background()
 
-	_, insertErr := verificationConn.Exec(ctx,
+	_, err := verificationConn.Exec(ctx,
 		"INSERT INTO collections.collections (name, description, node_id) VALUES (@name, @description, @node_id)",
 		pgx.NamedArgs{
 			"name":        "",
 			"description": uuid.NewString(),
 			"node_id":     uuid.NewString()},
 	)
+	require.Error(t, err)
 
 	emptyNameRows, err := verificationConn.Query(ctx, "SELECT id FROM collections.collections WHERE name = ''")
 	require.NoError(t, err)
@@ -147,7 +148,6 @@ func testPreventEmptyName(t *testing.T, migrator *dbmigrate.CollectionsMigrator,
 	require.NoError(t, err)
 	assert.Empty(t, emptyNameIDs)
 
-	require.Error(t, insertErr)
 }
 
 func testPreventWhiteSpaceName(t *testing.T, migrator *dbmigrate.CollectionsMigrator, verificationConn *pgx.Conn) {
@@ -156,13 +156,14 @@ func testPreventWhiteSpaceName(t *testing.T, migrator *dbmigrate.CollectionsMigr
 	ctx := context.Background()
 
 	whiteSpaceName := "   "
-	_, insertErr := verificationConn.Exec(ctx,
+	_, err := verificationConn.Exec(ctx,
 		"INSERT INTO collections.collections (name, description, node_id) VALUES (@name, @description, @node_id)",
 		pgx.NamedArgs{
 			"name":        whiteSpaceName,
 			"description": uuid.NewString(),
 			"node_id":     uuid.NewString()},
 	)
+	require.Error(t, err)
 
 	emptyNameRows, err := verificationConn.Query(ctx, "SELECT id FROM collections.collections WHERE name = @white_space_name",
 		pgx.NamedArgs{"white_space_name": whiteSpaceName})
@@ -172,5 +173,4 @@ func testPreventWhiteSpaceName(t *testing.T, migrator *dbmigrate.CollectionsMigr
 	require.NoError(t, err)
 	assert.Empty(t, emptyNameIDs)
 
-	require.Error(t, insertErr)
 }

--- a/internal/dbmigrate/migrations/20250421162715_empty_name_check.down.sql
+++ b/internal/dbmigrate/migrations/20250421162715_empty_name_check.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collections
+    DROP CONSTRAINT IF EXISTS check_non_empty_name;

--- a/internal/dbmigrate/migrations/20250421162715_empty_name_check.up.sql
+++ b/internal/dbmigrate/migrations/20250421162715_empty_name_check.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE collections
+    ADD CONSTRAINT check_non_empty_name CHECK (TRIM(name) <> '');

--- a/internal/dbmigrate/migrations/20250422101951_empty_doi_check.down.sql
+++ b/internal/dbmigrate/migrations/20250422101951_empty_doi_check.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dois
+    DROP CONSTRAINT IF EXISTS check_non_empty_doi;

--- a/internal/dbmigrate/migrations/20250422101951_empty_doi_check.up.sql
+++ b/internal/dbmigrate/migrations/20250422101951_empty_doi_check.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE dois
+    ADD CONSTRAINT check_non_empty_doi CHECK (TRIM(doi) <> '');


### PR DESCRIPTION
PR adds check constraints to the tables `collections` and `dois` to prevent empty strings or strings of whitespace from being saved to the DB for the fields `collections.name` and `dois.doi`, these being non-null fields provided by users.

Also updates the CreateCollection route to trim whitespace from these fields before saving them in the DB.