### PR TITLE
Fix: Check for unknown request fields

### DIFF
--- a/internal/api/apierrors/errors.go
+++ b/internal/api/apierrors/errors.go
@@ -31,7 +31,8 @@ func NewInternalServerError(userMessage string, cause error) *Error {
 }
 
 func NewRequestUnmarshallError(bodyType any, cause error) *Error {
-	return NewBadRequestErrorWithCause(fmt.Sprintf("error unmarshalling request body to %T", bodyType), cause)
+	// Adding the cause to the user message, since it can be useful for the user to figure out how to fix the request
+	return NewBadRequestErrorWithCause(fmt.Sprintf("error unmarshalling request body to %T: %v", bodyType, cause), cause)
 }
 
 func NewBadRequestError(userMessage string) *Error {

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -37,6 +37,7 @@ func CollectionsServiceAPIHandler(
 		logger := logging.Default.With(slog.String("routeKey", routeKey),
 			slog.String("requestId", request.RequestContext.RequestID))
 		container.SetLogger(logger)
+
 		logger.Debug("configuration",
 			slog.Group("postgres",
 				slog.String("user", config.PostgresDB.User),

--- a/internal/test/apitest/apigateway.go
+++ b/internal/test/apitest/apigateway.go
@@ -34,9 +34,14 @@ func (b *APIGatewayRequestBuilder) WithDefaultClaims(seedUser SeedUser) *APIGate
 }
 
 func (b *APIGatewayRequestBuilder) WithBody(t require.TestingT, bodyStruct any) *APIGatewayRequestBuilder {
-	bodyBytes, err := json.Marshal(bodyStruct)
-	require.NoError(t, err)
-	b.r.Body = string(bodyBytes)
+	switch v := bodyStruct.(type) {
+	case string:
+		b.r.Body = v
+	default:
+		bodyBytes, err := json.Marshal(bodyStruct)
+		require.NoError(t, err)
+		b.r.Body = string(bodyBytes)
+	}
 	return b
 }
 


### PR DESCRIPTION
PR updates the `CreateCollection` route to use a JSON Decoder configured to reject unknown fields when decoding into the DTO struct. We return this to the user as a HTTP 400 Bad Request response with an error message from the decoder to help them diagnose the problem.

This will give better feedback when the request contains a typo, `doi` instead of `dois` for example.