### PR TITLE
Fix CORS configuration

### DIFF
--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -4,7 +4,7 @@ resource "aws_apigatewayv2_api" "collections_service_api" {
   description   = "API for the lambda-based Collections API"
   cors_configuration {
     allow_origins = ["*"]
-    allow_methods = ["*"]
+    allow_methods = ["OPTIONS", "GET", "POST", "PATCH"]
     allow_headers = ["*"]
     expose_headers = ["*"]
     max_age = 300


### PR DESCRIPTION
When using authorization, a `*` value for `Access-Control-Allowed-Methods` is not interpreted as a wildcard, but literally.

This is not a problem if only using `GET` and `POST` since they are considered safe, and always allowed. Since we use `PATCH` (and authorization), we need to specify the allowed methods explicitly.

source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Access-Control-Allow-Methods