### PR TITLE
Fix: CORS and auth

### DIFF
--- a/terraform/gateway.tf
+++ b/terraform/gateway.tf
@@ -1,13 +1,14 @@
 resource "aws_apigatewayv2_api" "collections_service_api" {
-  name          = "Serverless Collections API"
+  name          = "Collections Serverless API"
   protocol_type = "HTTP"
   description   = "API for the lambda-based Collections API"
   cors_configuration {
-    allow_origins = ["*"]
+    allow_origins     = local.cors_allowed_origins
     allow_methods = ["OPTIONS", "GET", "POST", "PATCH"]
     allow_headers = ["*"]
+    allow_credentials = true
     expose_headers = ["*"]
-    max_age = 300
+    max_age           = 300
   }
   body = templatefile("${path.module}/collections-service.yml", {
     authorize_lambda_invoke_uri    = data.terraform_remote_state.api_gateway.outputs.authorizer_lambda_invoke_uri

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,4 +38,5 @@ locals {
   discover_service_host = data.terraform_remote_state.discover_service.outputs.internal_fqdn
   pennsieve_doi_prefix  = var.environment_name == "prod" ? "10.26275" : "10.21397"
   log_level             = var.environment_name == "prod" ? "INFO" : "DEBUG"
+  cors_allowed_origins  = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
 }


### PR DESCRIPTION
PR adds a few changes to the API Gateway CORS config that seem to be necessary to use both the PATCH method and authentication.