### PR TITLE
FIX: Prevent adding unpublished DOIs

### DIFF
--- a/internal/api/routes/create_collection.go
+++ b/internal/api/routes/create_collection.go
@@ -56,12 +56,8 @@ func CreateCollection(ctx context.Context, params Params) (dto.CreateCollectionR
 			return dto.CreateCollectionResponse{}, apierrors.NewInternalServerError("error looking up DOIs in Discover", err)
 		}
 
-		if len(datasetResults.Unpublished) > 0 {
-			var details []string
-			for _, unpublished := range datasetResults.Unpublished {
-				details = append(details, fmt.Sprintf("%s status is %s", unpublished.DOI, unpublished.Status))
-			}
-			return dto.CreateCollectionResponse{}, apierrors.NewBadRequestError(fmt.Sprintf("request contains unpublished DOIs: %s", strings.Join(details, ", ")))
+		if err := CheckForUnpublished(datasetResults); err != nil {
+			return dto.CreateCollectionResponse{}, err
 		}
 
 		response.Banners = collectBanners(pennsieveDOIs, datasetResults.Published)

--- a/internal/api/routes/dois.go
+++ b/internal/api/routes/dois.go
@@ -2,6 +2,8 @@ package routes
 
 import (
 	"fmt"
+	"github.com/pennsieve/collections-service/internal/api/apierrors"
+	"github.com/pennsieve/collections-service/internal/api/service"
 	"strings"
 )
 
@@ -24,4 +26,15 @@ func CategorizeDOIs(pennsieveDOIPrefix string, dois []string) (pennsieveDOIs []s
 		}
 	}
 	return
+}
+
+func CheckForUnpublished(datasetResults service.DatasetsByDOIResponse) error {
+	if len(datasetResults.Unpublished) > 0 {
+		var details []string
+		for _, unpublished := range datasetResults.Unpublished {
+			details = append(details, fmt.Sprintf("%s status is %s", unpublished.DOI, unpublished.Status))
+		}
+		return apierrors.NewBadRequestError(fmt.Sprintf("request contains unpublished DOIs: %s", strings.Join(details, ", ")))
+	}
+	return nil
 }


### PR DESCRIPTION
PR fixes an oversight that allowed users to add unpublished DOIs to a collection with a `PATCH`, i.e., update, operation. This was already being prevented during `POST`, i.e., create, but was missed for updates.