### PR TITLE
Add Postgres Indices

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -11,4 +11,4 @@ COPY cmd cmd
 COPY internal internal
 RUN ["go", "mod", "tidy"]
 
-CMD ["go", "test", "-v", "-p", "1", "./..."]
+CMD ["go", "test", "-v", "./..."]

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ local-services:
 	docker compose -f docker-compose.test.yml -f docker-compose.local.override.yml up -d pennsievedb-collections
 
 test: local-services
-	go test -v -p 1 ./...
+	go test -v ./...
 
 test-ci:
 	docker compose -f docker-compose.test.yml down --remove-orphans

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,7 +24,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   pennsievedb-collections:
-    image: pennsieve/pennsievedb-collections:20250508222721-seed
+    image: pennsieve/pennsievedb-collections:20250515223535-seed
     restart: always
 #    command: [ "postgres", "-c", "log_statement=all" ]
 

--- a/internal/api/routes/get_collection.go
+++ b/internal/api/routes/get_collection.go
@@ -25,6 +25,8 @@ func GetCollection(ctx context.Context, params Params) (dto.GetCollectionRespons
 		slog.String(NodeIDPathParamKey, nodeID),
 		slog.String("userNodeId", userClaim.NodeId))
 
+	// GetCollection only returns the collection if the given user has >= Guest permission,
+	// so no further authz is required for this route.
 	storeResp, err := params.Container.CollectionsStore().GetCollection(ctx, userClaim.Id, nodeID)
 	if err != nil {
 		if errors.Is(err, store.ErrCollectionNotFound) {

--- a/internal/api/routes/get_collections.go
+++ b/internal/api/routes/get_collections.go
@@ -29,6 +29,9 @@ func GetCollections(ctx context.Context, params Params) (dto.GetCollectionsRespo
 	}
 	collectionsStore := params.Container.CollectionsStore()
 	userClaim := params.Claims.UserClaim
+
+	// GetCollections only returns collections where the given user has >= Guest permission,
+	// so no further authz is required for this route.
 	storeResp, err := collectionsStore.GetCollections(ctx, userClaim.Id, limit, offset)
 	if err != nil {
 		return dto.GetCollectionsResponse{}, apierrors.NewInternalServerError(fmt.Sprintf("error getting collections for user %s", userClaim.NodeId), err)

--- a/internal/api/store/collections.go
+++ b/internal/api/store/collections.go
@@ -16,7 +16,9 @@ const MaxBannerDOIsPerCollection = config.MaxBannersPerCollection
 
 type CollectionsStore interface {
 	CreateCollection(ctx context.Context, userID int64, nodeID, name, description string, dois []DOI) (CreateCollectionResponse, error)
+	// GetCollections returns a paginated list of collection summaries that the given user has at least guest permission on.
 	GetCollections(ctx context.Context, userID int64, limit int, offset int) (GetCollectionsResponse, error)
+	// GetCollection returns a the given collection if it exists and if the given user has at least guest permission on it.
 	GetCollection(ctx context.Context, userID int64, nodeID string) (GetCollectionResponse, error)
 	DeleteCollection(ctx context.Context, collectionID int64) error
 	UpdateCollection(ctx context.Context, userID, collectionID int64, update UpdateCollectionRequest) (GetCollectionResponse, error)
@@ -101,15 +103,16 @@ func (s *PostgresCollectionsStore) GetCollections(ctx context.Context, userID in
 
 	}
 	getCollectionsArgs := pgx.NamedArgs{
-		"user_id": userID,
-		"limit":   limit,
-		"offset":  offset,
+		"user_id":  userID,
+		"limit":    limit,
+		"offset":   offset,
+		"min_perm": pgdb.Guest,
 	}
 	// using ORDER BY c.id asc as a proxy for getting in order of creation, oldest first
 	getCollectionsSQL := `SELECT c.id, c.name, c.description, c.node_id, u.role, count(*) OVER () AS total_count
 			FROM collections.collections c
          			JOIN collections.collection_user u ON c.id = u.collection_id
-			WHERE u.user_id = @user_id
+			WHERE u.user_id = @user_id AND u.permission_bit >= @min_perm
 			ORDER BY c.id asc
 			LIMIT @limit OFFSET @offset`
 
@@ -124,7 +127,8 @@ func (s *PostgresCollectionsStore) GetCollections(ctx context.Context, userID in
 
 	response := GetCollectionsResponse{Limit: limit, Offset: offset}
 
-	var collectionIDs []int64
+	// limit may be zero
+	collectionIDs := make([]int64, 0, limit+1)
 	collections, err := pgx.CollectRows(collectionUserJoinRows, func(row pgx.CollectableRow) (CollectionSummary, error) {
 		var id int64
 		var name, description, nodeID string
@@ -160,7 +164,7 @@ func (s *PostgresCollectionsStore) GetCollections(ctx context.Context, userID in
 		if err := conn.QueryRow(ctx, `SELECT count(*)
 	                                FROM collections.collections c
 	         			            	JOIN collections.collection_user u ON c.id = u.collection_id
-				                    WHERE u.user_id = @user_id`, getCollectionsArgs).Scan(&totalCount); err != nil {
+				                    WHERE u.user_id = @user_id AND u.permission_bit >= @min_perm`, getCollectionsArgs).Scan(&totalCount); err != nil {
 			return GetCollectionsResponse{}, fmt.Errorf("GetCollections: error counting total collections: %w", err)
 		}
 		response.TotalCount = totalCount
@@ -207,7 +211,7 @@ func (s *PostgresCollectionsStore) GetCollections(ctx context.Context, userID in
 // getCollectionByIDColumn returns the error ErrCollectionNotFound if no collection with the given idValue exists for the given user id.
 // idColumn should be either "id" or "node_id"
 func getCollectionByIDColumn(ctx context.Context, conn *pgx.Conn, userID int64, idColumn string, idValue any) (GetCollectionResponse, error) {
-	args := pgx.NamedArgs{"user_id": userID, idColumn: idValue}
+	args := pgx.NamedArgs{"user_id": userID, idColumn: idValue, "min_perm": pgdb.Guest}
 
 	idCondition := fmt.Sprintf("c.%s = @%s", idColumn, idColumn)
 
@@ -215,7 +219,7 @@ func getCollectionByIDColumn(ctx context.Context, conn *pgx.Conn, userID int64, 
 			FROM collections.collections c
          		JOIN collections.collection_user u ON c.id = u.collection_id
          		LEFT JOIN collections.dois d ON c.id = d.collection_id
-			WHERE u.user_id = @user_id
+			WHERE u.user_id = @user_id AND u.permission_bit >= @min_perm
   			  AND %s
 			ORDER BY d.id asc`, idCondition)
 

--- a/internal/dbmigrate/migrations/20250515223535_add_indices.down.sql
+++ b/internal/dbmigrate/migrations/20250515223535_add_indices.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS collection_user_user_collection_idx;
+
+DROP INDEX IF EXISTS dois_collection_id_id_idx;

--- a/internal/dbmigrate/migrations/20250515223535_add_indices.down.sql
+++ b/internal/dbmigrate/migrations/20250515223535_add_indices.down.sql
@@ -1,3 +1,6 @@
 DROP INDEX IF EXISTS collection_user_user_collection_idx;
 
 DROP INDEX IF EXISTS dois_collection_id_id_idx;
+
+CREATE INDEX IF NOT EXISTS collection_user_user_id_idx
+    on collection_user (user_id);

--- a/internal/dbmigrate/migrations/20250515223535_add_indices.up.sql
+++ b/internal/dbmigrate/migrations/20250515223535_add_indices.up.sql
@@ -3,3 +3,5 @@ CREATE INDEX collection_user_user_perm_coll_idx
 
 CREATE INDEX IF NOT EXISTS dois_collection_id_id_idx
     ON collections.dois (collection_id, id);
+
+DROP INDEX IF EXISTS collection_user_user_id_idx;

--- a/internal/dbmigrate/migrations/20250515223535_add_indices.up.sql
+++ b/internal/dbmigrate/migrations/20250515223535_add_indices.up.sql
@@ -1,5 +1,5 @@
-CREATE INDEX collection_user_user_collection_idx
-    ON collection_user (user_id, collection_id);
+CREATE INDEX collection_user_user_perm_coll_idx
+    ON collections.collection_user (user_id, permission_bit, collection_id);
 
 CREATE INDEX IF NOT EXISTS dois_collection_id_id_idx
     ON collections.dois (collection_id, id);

--- a/internal/dbmigrate/migrations/20250515223535_add_indices.up.sql
+++ b/internal/dbmigrate/migrations/20250515223535_add_indices.up.sql
@@ -1,0 +1,5 @@
+CREATE INDEX collection_user_user_collection_idx
+    ON collection_user (user_id, collection_id);
+
+CREATE INDEX IF NOT EXISTS dois_collection_id_id_idx
+    ON collections.dois (collection_id, id);


### PR DESCRIPTION
PR adds a couple of indices to the collections schema to aid in the look up of collections.

Modifies the GetCollections query to remove a `*`.

Also allows parallel package tests.