### PR TITLE
Collections cannot contain collections

### DIFF
--- a/internal/api/dto/collection.go
+++ b/internal/api/dto/collection.go
@@ -169,6 +169,8 @@ func (d *Date) UnmarshalText(data []byte) error {
 	return nil
 }
 
+const CollectionDatasetType = "collection"
+
 // PublicDataset and it's child DTOs are taken from the Discover service so that
 // our responses match those of Discover.
 type PublicDataset struct {

--- a/internal/api/routes/create_collection.go
+++ b/internal/api/routes/create_collection.go
@@ -59,7 +59,7 @@ func CreateCollection(ctx context.Context, params Params) (dto.CreateCollectionR
 			return dto.CreateCollectionResponse{}, apierrors.NewInternalServerError("error looking up DOIs in Discover", err)
 		}
 
-		if err := CheckForUnpublished(datasetResults); err != nil {
+		if err := ValidateDiscoverResponse(datasetResults); err != nil {
 			return dto.CreateCollectionResponse{}, err
 		}
 

--- a/internal/api/routes/patch_collection.go
+++ b/internal/api/routes/patch_collection.go
@@ -82,7 +82,7 @@ func PatchCollection(ctx context.Context, params Params) (dto.GetCollectionRespo
 				"error querying Discover for DOIs to add during update",
 				err)
 		}
-		if err := CheckForUnpublished(discoverResp); err != nil {
+		if err := ValidateDiscoverResponse(discoverResp); err != nil {
 			return dto.GetCollectionResponse{}, err
 		}
 	}

--- a/internal/test/apitest/datasets.go
+++ b/internal/test/apitest/datasets.go
@@ -41,6 +41,12 @@ func WithPublicContributors(contributors ...dto.PublicContributor) PublicDataset
 	}
 }
 
+func WithDatasetType(datasetType string) PublicDatasetOption {
+	return func(publicDataset *dto.PublicDataset) {
+		publicDataset.DatasetType = &datasetType
+	}
+}
+
 func (e *ExpectedPennsieveDatasets) NewPublishedWithOptions(opts ...PublicDatasetOption) dto.PublicDataset {
 	doi := NewPennsieveDOI()
 	banner := NewBanner()


### PR DESCRIPTION
PR updates the validation done during collection creation and update to return a Bad Request response if the request contains a Pennsieve dataset with type `collection`. 