### PR TITLE
Terraform Fixes

### DIFF
--- a/terraform/collections-service.yml
+++ b/terraform/collections-service.yml
@@ -211,6 +211,13 @@ paths:
       summary: publishes a new public version of the given collection
       description: |
         Publishes a new version of the collection
+      parameters:
+        - name: nodeId
+          in: path
+          required: true
+          schema:
+            type: string
+          description: ID of the collection node to publish
       requestBody:
         required: true
         content:

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -26,3 +26,14 @@ resource "aws_ssm_parameter" "postgres_database" {
   type  = "String"
   value = var.pennsieve_postgres_database
 }
+
+# JWT Secret Key used by the API Lambda
+resource "aws_ssm_parameter" "jwt_secret_key" {
+  name  = "/${var.environment_name}/${var.service_name}/jwt-secret-key"
+  type  = "SecureString"
+  value = "dummy"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+}


### PR DESCRIPTION
PR #35 missed adding the `nodeId` path param to the OpenAPI spec.

PR #33 missed adding a new SSM parameter for the JWT signing key.

