### PR TITLE
Fix SSM Parameter Path

### DIFF
--- a/internal/api/config/pennsieve.go
+++ b/internal/api/config/pennsieve.go
@@ -38,7 +38,7 @@ func WithDOIPrefix(doiPrefix string) PennsieveOption {
 
 func WithJWTSecretKey(jwtSecretKey string) PennsieveOption {
 	return func(pennsieveConfig *PennsieveConfig) {
-		pennsieveConfig.JWTSecretKey = JWTSecretKeySetting.WithValue(jwtSecretKey)
+		pennsieveConfig.JWTSecretKey = NewJWTSecretKeySetting().WithValue(jwtSecretKey)
 	}
 }
 
@@ -54,11 +54,11 @@ func WithPublishBucket(publishBucket string) PennsieveOption {
 	}
 }
 
-// LoadWithEnvSettings returns a copy of this PennsieveConfig where any missing fields are populated by the
-// given PennsieveEnvironmentSettings.
-func (c PennsieveConfig) LoadWithEnvSettings(environmentName string, environmentSettings PennsieveEnvironmentSettings) (PennsieveConfig, error) {
+// LoadWithSettings returns a copy of this PennsieveConfig where any missing fields are populated by the
+// given PennsieveSettings.
+func (c PennsieveConfig) LoadWithSettings(environmentName string, settings PennsieveSettings) (PennsieveConfig, error) {
 	if len(c.DiscoverServiceURL) == 0 {
-		url, err := environmentSettings.DiscoverServiceHost.Get()
+		url, err := settings.DiscoverServiceHost.Get()
 		if err != nil {
 			return PennsieveConfig{}, err
 		}
@@ -68,14 +68,14 @@ func (c PennsieveConfig) LoadWithEnvSettings(environmentName string, environment
 		c.DiscoverServiceURL = url
 	}
 	if len(c.DOIPrefix) == 0 {
-		prefix, err := environmentSettings.DOIPrefix.Get()
+		prefix, err := settings.DOIPrefix.Get()
 		if err != nil {
 			return PennsieveConfig{}, err
 		}
 		c.DOIPrefix = prefix
 	}
 	if c.CollectionNamespaceID == 0 {
-		namespaceID, err := environmentSettings.CollectionNamespaceID.GetInt64()
+		namespaceID, err := settings.CollectionNamespaceID.GetInt64()
 		if err != nil {
 			return PennsieveConfig{}, err
 		}
@@ -83,19 +83,22 @@ func (c PennsieveConfig) LoadWithEnvSettings(environmentName string, environment
 	}
 
 	if len(c.PublishBucket) == 0 {
-		publishBucket, err := environmentSettings.PublishBucket.Get()
+		publishBucket, err := settings.PublishBucket.Get()
 		if err != nil {
 			return PennsieveConfig{}, err
 		}
 		c.PublishBucket = publishBucket
 	}
 
-	c.JWTSecretKey = JWTSecretKeySetting.WithEnvironment(environmentName)
+	if c.JWTSecretKey == nil {
+		c.JWTSecretKey = settings.JWTSecretKey.WithEnvironment(environmentName)
+	}
+
 	return c, nil
 }
 
 // Load returns a copy of this PennsieveConfig where any missing fields are populated by the
-// given DeployedPennsieveEnvironmentSettings.
+// given DeployedPennsieveSettings.
 func (c PennsieveConfig) Load(environmentName string) (PennsieveConfig, error) {
-	return c.LoadWithEnvSettings(environmentName, DeployedPennsieveEnvironmentSettings)
+	return c.LoadWithSettings(environmentName, DeployedPennsieveSettings)
 }

--- a/internal/api/config/pennsieve_test.go
+++ b/internal/api/config/pennsieve_test.go
@@ -1,0 +1,39 @@
+package config
+
+import (
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"strconv"
+	"testing"
+)
+
+func TestPennsieveConfig_Load(t *testing.T) {
+	expectedDiscoverHost := uuid.NewString()
+	expectedPennsieveDOIPrefix := uuid.NewString()
+	expectedCollectionNamespaceID := int64(-20)
+	expectedPublishBucket := uuid.NewString()
+
+	t.Setenv(DiscoverServiceHostKey, expectedDiscoverHost)
+	t.Setenv(PennsieveDOIPrefixKey, expectedPennsieveDOIPrefix)
+	t.Setenv(CollectionNamespaceIDKey, strconv.FormatInt(expectedCollectionNamespaceID, 10))
+	t.Setenv(PublishBucketKey, expectedPublishBucket)
+
+	expectedEnvironment := uuid.NewString()
+	config, err := NewPennsieveConfig().Load(expectedEnvironment)
+	require.NoError(t, err)
+
+	assert.Equal(t, fmt.Sprintf("https://%s", expectedDiscoverHost), config.DiscoverServiceURL)
+	assert.Equal(t, expectedPennsieveDOIPrefix, config.DOIPrefix)
+	assert.Equal(t, expectedCollectionNamespaceID, config.CollectionNamespaceID)
+	assert.Equal(t, expectedPublishBucket, config.PublishBucket)
+
+	assert.NotNil(t, config.JWTSecretKey)
+
+	if assert.NotNil(t, config.JWTSecretKey.Environment) {
+		assert.Equal(t, expectedEnvironment, *config.JWTSecretKey.Environment)
+	}
+	assert.Equal(t, ServiceName, config.JWTSecretKey.Service)
+	assert.Equal(t, JWTSecretKeySSMName, config.JWTSecretKey.Name)
+}

--- a/internal/api/config/pennsieveenv.go
+++ b/internal/api/config/pennsieveenv.go
@@ -10,18 +10,22 @@ const PublishBucketKey = "PUBLISH_BUCKET"
 const ServiceName = "collections-service"
 const JWTSecretKeySSMName = "jwt-secret-key"
 
-type PennsieveEnvironmentSettings struct {
+type PennsieveSettings struct {
 	DiscoverServiceHost   sharedconfig.EnvironmentSetting
 	DOIPrefix             sharedconfig.EnvironmentSetting
 	CollectionNamespaceID sharedconfig.EnvironmentSetting
 	PublishBucket         sharedconfig.EnvironmentSetting
+	JWTSecretKey          *sharedconfig.SSMSetting
 }
 
-var DeployedPennsieveEnvironmentSettings = PennsieveEnvironmentSettings{
+var DeployedPennsieveSettings = PennsieveSettings{
 	DiscoverServiceHost:   sharedconfig.NewEnvironmentSetting(DiscoverServiceHostKey),
 	DOIPrefix:             sharedconfig.NewEnvironmentSetting(PennsieveDOIPrefixKey),
 	CollectionNamespaceID: sharedconfig.NewEnvironmentSetting(CollectionNamespaceIDKey),
 	PublishBucket:         sharedconfig.NewEnvironmentSetting(PublishBucketKey),
+	JWTSecretKey:          NewJWTSecretKeySetting(),
 }
 
-var JWTSecretKeySetting = sharedconfig.NewSSMSetting(ServiceName, JWTSecretKeySSMName)
+func NewJWTSecretKeySetting() *sharedconfig.SSMSetting {
+	return sharedconfig.NewSSMSetting(ServiceName, JWTSecretKeySSMName)
+}

--- a/internal/shared/config/ssm.go
+++ b/internal/shared/config/ssm.go
@@ -26,10 +26,10 @@ func (s *SSMSetting) Load(ctx context.Context, lookup SSMLookupFunc) (string, er
 		if s.Environment == nil {
 			return "", fmt.Errorf("environment not set for SSM setting")
 		}
-		key := fmt.Sprintf("%s/%s/%s", *s.Environment, s.Service, s.Name)
-		value, err := lookup(ctx, key)
+		paramKey := key(*s.Environment, s.Service, s.Name)
+		value, err := lookup(ctx, paramKey)
 		if err != nil {
-			return "", fmt.Errorf("error getting %s value from SSM: %w", key, err)
+			return "", fmt.Errorf("error getting %s value from SSM: %w", paramKey, err)
 		}
 		s.Value = &value
 	}
@@ -44,7 +44,7 @@ func (s *SSMSetting) String() string {
 	if s.Environment != nil {
 		env = *s.Environment
 	}
-	return fmt.Sprintf("%s/%s/%s", env, s.Service, s.Name)
+	return key(env, s.Service, s.Name)
 }
 
 func (s *SSMSetting) WithEnvironment(env string) *SSMSetting {
@@ -56,4 +56,8 @@ func (s *SSMSetting) WithEnvironment(env string) *SSMSetting {
 func (s *SSMSetting) WithValue(value string) *SSMSetting {
 	s.Value = &value
 	return s
+}
+
+func key(env, service, name string) string {
+	return fmt.Sprintf("/%s/%s/%s", env, service, name)
 }

--- a/internal/shared/config/ssm_test.go
+++ b/internal/shared/config/ssm_test.go
@@ -1,0 +1,28 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+// TestSSMSetting_Key tests that key is correctly constructed. Initially we were missing the leading '/' in the key
+func TestSSMSetting_Key(t *testing.T) {
+
+	env, service, name := "test-env", "test-service", "test-param-name"
+
+	setting := NewSSMSetting(service, name).WithEnvironment(env)
+
+	expectedKey := fmt.Sprintf("/%s/%s/%s", env, service, name)
+	expectedValue := uuid.NewString()
+	actualValue, err := setting.Load(context.Background(), func(ctx context.Context, key string) (string, error) {
+		assert.Equal(t, expectedKey, key)
+		return expectedValue, nil
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, expectedValue, actualValue)
+}


### PR DESCRIPTION
Missing the leading `'/'` in SSM parameter paths.