### PR TITLE
Fix Missing field in Discover Publish Request

### DIFF
--- a/internal/api/service/discover_models.go
+++ b/internal/api/service/discover_models.go
@@ -1,23 +1,64 @@
 package service
 
-import "github.com/pennsieve/collections-service/internal/api/dto"
+import (
+	"encoding/json"
+	"github.com/pennsieve/collections-service/internal/api/dto"
+)
 
 // Some Discover models, such as PublicDatasetDTO live in api/dto because we use them as DTOs as well.
 // Here we just have types that are only used internally by us.
 
 type PublishDOICollectionRequest struct {
-	Name             string   `json:"name"`
-	Description      string   `json:"description"`
-	Banners          []string `json:"banners"` // max 4 items
-	DOIs             []string `json:"dois"`    // min 1 item
-	License          string   `json:"license"`
-	Tags             []string `json:"tags"`
-	OwnerID          int64    `json:"ownerId"`
-	OwnerNodeID      string   `json:"ownerNodeId"`
-	OwnerFirstName   string   `json:"ownerFirstName"`
-	OwnerLastName    string   `json:"ownerLastName"`
-	OwnerORCID       string   `json:"ownerOrcid"`
-	CollectionNodeID string   `json:"collectionNodeId"`
+	// Required Values
+
+	Name             string                `json:"name"`
+	Description      string                `json:"description"`
+	Banners          []string              `json:"banners"` // max 4 items
+	DOIs             []string              `json:"dois"`    // min 1 item
+	OwnerID          int64                 `json:"ownerId"`
+	License          string                `json:"license"`
+	Contributors     []InternalContributor `json:"contributors"`
+	Tags             []string              `json:"tags"`
+	OwnerNodeID      string                `json:"ownerNodeId"`
+	OwnerFirstName   string                `json:"ownerFirstName"`
+	OwnerLastName    string                `json:"ownerLastName"`
+	OwnerORCID       string                `json:"ownerOrcid"`
+	CollectionNodeID string                `json:"collectionNodeId"`
+
+	// Optional Values have been left out for now. Can be added as they come up
+}
+
+func (r PublishDOICollectionRequest) MarshalJSON() ([]byte, error) {
+	if r.Banners == nil {
+		r.Banners = []string{}
+	}
+	if r.DOIs == nil {
+		r.DOIs = []string{}
+	}
+	if r.Contributors == nil {
+		r.Contributors = []InternalContributor{}
+	}
+	if r.Tags == nil {
+		r.Tags = []string{}
+	}
+	type alias PublishDOICollectionRequest
+	return json.Marshal(alias(r))
+}
+
+type InternalContributor struct {
+	//Required Values
+
+	// ID is an internal contributor id, different from a user id.
+	ID        int64  `json:"id"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+
+	//Optional Values
+
+	ORCID         string `json:"orcid,omitempty"`
+	MiddleInitial string `json:"middleInitial,omitempty"`
+	Degree        string `json:"degree,omitempty"`
+	UserID        int64  `json:"userId,omitempty"`
 }
 
 type PublishDOICollectionResponse struct {
@@ -30,6 +71,8 @@ type PublishDOICollectionResponse struct {
 }
 
 type FinalizeDOICollectionPublishRequest struct {
+	// All Values Required
+
 	PublishedDatasetID int64  `json:"publishedDatasetId"`
 	PublishedVersion   int64  `json:"publishedVersion"`
 	PublishSuccess     bool   `json:"publishSuccess"`

--- a/internal/api/service/discover_models_test.go
+++ b/internal/api/service/discover_models_test.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPublishDOICollectionRequest_Marshal(t *testing.T) {
+
+	request := PublishDOICollectionRequest{}
+
+	reqBytes, err := json.Marshal(request)
+	require.NoError(t, err)
+	reqJSONString := string(reqBytes)
+
+	// Test that required slice values are marshalled as empty arrays rather than nulls.
+	requiredArrays := []string{"banners", "dois", "contributors", "tags"}
+
+	for _, requiredArray := range requiredArrays {
+		t.Run(fmt.Sprintf("%s is [] and not null", requiredArray), func(t *testing.T) {
+			isNull := fmt.Sprintf(`%q:null`, requiredArray)
+			isEmpty := fmt.Sprintf(`%q:[]`, requiredArray)
+			assert.NotContains(t, reqJSONString, isNull)
+			assert.Contains(t, reqJSONString, isEmpty)
+		})
+
+	}
+}


### PR DESCRIPTION
Discover requires a `"contributors"` array in the DOI Collection publish request. PR adds that field to the model unpopulated for now.