### PR TITLE
Use ID space exported by Discover Service

### DIFF
--- a/internal/api/config/pennsieve.go
+++ b/internal/api/config/pennsieve.go
@@ -14,11 +14,6 @@ type PennsieveConfig struct {
 	PublishBucket        string
 }
 
-type IDSpace struct {
-	ID   int64
-	Name string
-}
-
 func NewPennsieveConfig(options ...PennsieveOption) PennsieveConfig {
 	pennsieveConfig := PennsieveConfig{}
 	for _, option := range options {

--- a/internal/api/config/pennsieve.go
+++ b/internal/api/config/pennsieve.go
@@ -47,7 +47,7 @@ func WithJWTSecretKey(jwtSecretKey string) PennsieveOption {
 	}
 }
 
-func WithCollectionsIDSpace(id int64) PennsieveOption {
+func WithCollectionsIDSpaceID(id int64) PennsieveOption {
 	return func(pennsieveConfig *PennsieveConfig) {
 		pennsieveConfig.CollectionsIDSpaceID = id
 	}

--- a/internal/api/config/pennsieve.go
+++ b/internal/api/config/pennsieve.go
@@ -7,11 +7,16 @@ import (
 )
 
 type PennsieveConfig struct {
-	DiscoverServiceURL    string
-	DOIPrefix             string
-	JWTSecretKey          *sharedconfig.SSMSetting
-	CollectionNamespaceID int64
-	PublishBucket         string
+	DiscoverServiceURL   string
+	DOIPrefix            string
+	JWTSecretKey         *sharedconfig.SSMSetting
+	CollectionsIDSpaceID int64
+	PublishBucket        string
+}
+
+type IDSpace struct {
+	ID   int64
+	Name string
 }
 
 func NewPennsieveConfig(options ...PennsieveOption) PennsieveConfig {
@@ -42,9 +47,9 @@ func WithJWTSecretKey(jwtSecretKey string) PennsieveOption {
 	}
 }
 
-func WithCollectionNamespaceID(namespaceID int64) PennsieveOption {
+func WithCollectionsIDSpace(id int64) PennsieveOption {
 	return func(pennsieveConfig *PennsieveConfig) {
-		pennsieveConfig.CollectionNamespaceID = namespaceID
+		pennsieveConfig.CollectionsIDSpaceID = id
 	}
 }
 
@@ -74,12 +79,12 @@ func (c PennsieveConfig) LoadWithSettings(environmentName string, settings Penns
 		}
 		c.DOIPrefix = prefix
 	}
-	if c.CollectionNamespaceID == 0 {
-		namespaceID, err := settings.CollectionNamespaceID.GetInt64()
+	if c.CollectionsIDSpaceID == 0 {
+		idSpaceID, err := settings.CollectionsIDSpaceID.GetInt64()
 		if err != nil {
 			return PennsieveConfig{}, err
 		}
-		c.CollectionNamespaceID = namespaceID
+		c.CollectionsIDSpaceID = idSpaceID
 	}
 
 	if len(c.PublishBucket) == 0 {

--- a/internal/api/config/pennsieve_test.go
+++ b/internal/api/config/pennsieve_test.go
@@ -1,8 +1,10 @@
-package config
+package config_test
 
 import (
 	"fmt"
 	"github.com/google/uuid"
+	"github.com/pennsieve/collections-service/internal/api/config"
+	"github.com/pennsieve/collections-service/internal/test/apitest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"strconv"
@@ -12,28 +14,28 @@ import (
 func TestPennsieveConfig_Load(t *testing.T) {
 	expectedDiscoverHost := uuid.NewString()
 	expectedPennsieveDOIPrefix := uuid.NewString()
-	expectedCollectionNamespaceID := int64(-20)
+	expectedCollectionsIDSpaceID := apitest.CollectionsIDSpaceID
 	expectedPublishBucket := uuid.NewString()
 
-	t.Setenv(DiscoverServiceHostKey, expectedDiscoverHost)
-	t.Setenv(PennsieveDOIPrefixKey, expectedPennsieveDOIPrefix)
-	t.Setenv(CollectionNamespaceIDKey, strconv.FormatInt(expectedCollectionNamespaceID, 10))
-	t.Setenv(PublishBucketKey, expectedPublishBucket)
+	t.Setenv(config.DiscoverServiceHostKey, expectedDiscoverHost)
+	t.Setenv(config.PennsieveDOIPrefixKey, expectedPennsieveDOIPrefix)
+	t.Setenv(config.CollectionsIDSpaceIDKey, strconv.FormatInt(expectedCollectionsIDSpaceID, 10))
+	t.Setenv(config.PublishBucketKey, expectedPublishBucket)
 
 	expectedEnvironment := uuid.NewString()
-	config, err := NewPennsieveConfig().Load(expectedEnvironment)
+	actualConfig, err := config.NewPennsieveConfig().Load(expectedEnvironment)
 	require.NoError(t, err)
 
-	assert.Equal(t, fmt.Sprintf("https://%s", expectedDiscoverHost), config.DiscoverServiceURL)
-	assert.Equal(t, expectedPennsieveDOIPrefix, config.DOIPrefix)
-	assert.Equal(t, expectedCollectionNamespaceID, config.CollectionNamespaceID)
-	assert.Equal(t, expectedPublishBucket, config.PublishBucket)
+	assert.Equal(t, fmt.Sprintf("https://%s", expectedDiscoverHost), actualConfig.DiscoverServiceURL)
+	assert.Equal(t, expectedPennsieveDOIPrefix, actualConfig.DOIPrefix)
+	assert.Equal(t, expectedCollectionsIDSpaceID, actualConfig.CollectionsIDSpaceID)
+	assert.Equal(t, expectedPublishBucket, actualConfig.PublishBucket)
 
-	assert.NotNil(t, config.JWTSecretKey)
+	assert.NotNil(t, actualConfig.JWTSecretKey)
 
-	if assert.NotNil(t, config.JWTSecretKey.Environment) {
-		assert.Equal(t, expectedEnvironment, *config.JWTSecretKey.Environment)
+	if assert.NotNil(t, actualConfig.JWTSecretKey.Environment) {
+		assert.Equal(t, expectedEnvironment, *actualConfig.JWTSecretKey.Environment)
 	}
-	assert.Equal(t, ServiceName, config.JWTSecretKey.Service)
-	assert.Equal(t, JWTSecretKeySSMName, config.JWTSecretKey.Name)
+	assert.Equal(t, config.ServiceName, actualConfig.JWTSecretKey.Service)
+	assert.Equal(t, config.JWTSecretKeySSMName, actualConfig.JWTSecretKey.Name)
 }

--- a/internal/api/config/pennsieveenv.go
+++ b/internal/api/config/pennsieveenv.go
@@ -4,26 +4,26 @@ import sharedconfig "github.com/pennsieve/collections-service/internal/shared/co
 
 const DiscoverServiceHostKey = "DISCOVER_SERVICE_HOST"
 const PennsieveDOIPrefixKey = "PENNSIEVE_DOI_PREFIX"
-const CollectionNamespaceIDKey = "COLLECTION_NAMESPACE_ID"
+const CollectionsIDSpaceIDKey = "COLLECTIONS_ID_SPACE_ID"
 const PublishBucketKey = "PUBLISH_BUCKET"
 
 const ServiceName = "collections-service"
 const JWTSecretKeySSMName = "jwt-secret-key"
 
 type PennsieveSettings struct {
-	DiscoverServiceHost   sharedconfig.EnvironmentSetting
-	DOIPrefix             sharedconfig.EnvironmentSetting
-	CollectionNamespaceID sharedconfig.EnvironmentSetting
-	PublishBucket         sharedconfig.EnvironmentSetting
-	JWTSecretKey          *sharedconfig.SSMSetting
+	DiscoverServiceHost  sharedconfig.EnvironmentSetting
+	DOIPrefix            sharedconfig.EnvironmentSetting
+	CollectionsIDSpaceID sharedconfig.EnvironmentSetting
+	PublishBucket        sharedconfig.EnvironmentSetting
+	JWTSecretKey         *sharedconfig.SSMSetting
 }
 
 var DeployedPennsieveSettings = PennsieveSettings{
-	DiscoverServiceHost:   sharedconfig.NewEnvironmentSetting(DiscoverServiceHostKey),
-	DOIPrefix:             sharedconfig.NewEnvironmentSetting(PennsieveDOIPrefixKey),
-	CollectionNamespaceID: sharedconfig.NewEnvironmentSetting(CollectionNamespaceIDKey),
-	PublishBucket:         sharedconfig.NewEnvironmentSetting(PublishBucketKey),
-	JWTSecretKey:          NewJWTSecretKeySetting(),
+	DiscoverServiceHost:  sharedconfig.NewEnvironmentSetting(DiscoverServiceHostKey),
+	DOIPrefix:            sharedconfig.NewEnvironmentSetting(PennsieveDOIPrefixKey),
+	CollectionsIDSpaceID: sharedconfig.NewEnvironmentSetting(CollectionsIDSpaceIDKey),
+	PublishBucket:        sharedconfig.NewEnvironmentSetting(PublishBucketKey),
+	JWTSecretKey:         NewJWTSecretKeySetting(),
 }
 
 func NewJWTSecretKeySetting() *sharedconfig.SSMSetting {

--- a/internal/api/container/container.go
+++ b/internal/api/container/container.go
@@ -149,7 +149,7 @@ func (c *Container) InternalDiscover(ctx context.Context) (service.InternalDisco
 		c.internalDiscover = service.NewHTTPInternalDiscover(
 			c.Config.PennsieveConfig.DiscoverServiceURL,
 			jwtSecretKey,
-			c.Config.PennsieveConfig.CollectionNamespaceID,
+			c.Config.PennsieveConfig.CollectionsIDSpaceID,
 			c.Logger())
 	}
 	return c.internalDiscover, nil

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -46,7 +46,7 @@ func CollectionsServiceAPIHandler(
 			slog.Group("pennsieve",
 				slog.String("doiPrefix", config.PennsieveConfig.DOIPrefix),
 				slog.String("discoverURL", config.PennsieveConfig.DiscoverServiceURL),
-				slog.Int64("collectionNamespaceID", config.PennsieveConfig.CollectionNamespaceID),
+				slog.Int64("collectionsIDSpaceID", config.PennsieveConfig.CollectionsIDSpaceID),
 				slog.String("jwtSecretKey", config.PennsieveConfig.JWTSecretKey.String()),
 				slog.String("publishBucket", config.PennsieveConfig.PublishBucket),
 			),

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -104,7 +104,7 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 		Status:             expectedDiscoverPublishStatus,
 	}
 
-	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionNamespaceID)
+	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
 
 	mockFinalizeDOICollectionResponse := service.FinalizeDOICollectionPublishResponse{Status: dto.PublishSucceeded}
@@ -419,7 +419,7 @@ func testPublishSaveManifestFails(t *testing.T, expectationDB *fixtures.Expectat
 		Status:             expectedDiscoverPublishStatus,
 	}
 
-	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionNamespaceID)
+	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
 
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
@@ -522,7 +522,7 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 
 	s3Key := publishing.ManifestS3Key(expectedPublishedDatasetID)
 
-	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionNamespaceID)
+	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
 
 	var actualFinalizeRequests []service.FinalizeDOICollectionPublishRequest

--- a/internal/test/apitest/config.go
+++ b/internal/test/apitest/config.go
@@ -46,7 +46,7 @@ func PennsieveConfigWithOptions(opts ...config.PennsieveOption) config.Pennsieve
 		config.WithDiscoverServiceURL("http://example.com/discover"),
 		config.WithDOIPrefix(PennsieveDOIPrefix),
 		config.WithJWTSecretKey(uuid.NewString()),
-		config.WithCollectionsIDSpace(CollectionsIDSpaceID),
+		config.WithCollectionsIDSpaceID(CollectionsIDSpaceID),
 		config.WithPublishBucket(PublishBucket),
 	)
 	for _, opt := range opts {

--- a/internal/test/apitest/config.go
+++ b/internal/test/apitest/config.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 )
 
-const CollectionNamespaceID = int64(-20)
+const CollectionsIDSpaceID = int64(-20)
 const PublishBucket = "test-publish-bucket"
 
 type ConfigBuilder struct {
@@ -46,7 +46,7 @@ func PennsieveConfigWithOptions(opts ...config.PennsieveOption) config.Pennsieve
 		config.WithDiscoverServiceURL("http://example.com/discover"),
 		config.WithDOIPrefix(PennsieveDOIPrefix),
 		config.WithJWTSecretKey(uuid.NewString()),
-		config.WithCollectionNamespaceID(CollectionNamespaceID),
+		config.WithCollectionsIDSpace(CollectionsIDSpaceID),
 		config.WithPublishBucket(PublishBucket),
 	)
 	for _, opt := range opts {

--- a/internal/test/apitest/container.go
+++ b/internal/test/apitest/container.go
@@ -122,7 +122,7 @@ func (c *TestContainer) WithHTTPTestInternalDiscover(pennsieveConfig config.Penn
 	c.TestInternalDiscover = service.NewHTTPInternalDiscover(
 		pennsieveConfig.DiscoverServiceURL,
 		*pennsieveConfig.JWTSecretKey.Value,
-		pennsieveConfig.CollectionNamespaceID,
+		pennsieveConfig.CollectionsIDSpaceID,
 		c.Logger())
 	return c
 }

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -27,7 +27,7 @@ resource "aws_lambda_function" "collections_service_api_lambda" {
       POSTGRES_COLLECTIONS_DATABASE = var.pennsieve_postgres_database,
       DISCOVER_SERVICE_HOST         = local.discover_service_host,
       PENNSIEVE_DOI_PREFIX          = local.pennsieve_doi_prefix,
-      COLLECTION_NAMESPACE_ID       = local.collection_namespace_id,
+      COLLECTIONS_ID_SPACE_ID       = local.collections_id_space_id,
       PUBLISH_BUCKET                = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_name,
       LOG_LEVEL                     = local.log_level
     }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,10 +34,10 @@ locals {
     aws_region       = data.aws_region.current_region.name
     environment_name = var.environment_name
   }
-  rds_db_connect_arn      = "${replace(replace(data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint_arn, ":rds:", ":rds-db:"), ":db-proxy:", ":dbuser:")}/${var.api_postgres_user}"
-  discover_service_host   = data.terraform_remote_state.discover_service.outputs.internal_fqdn
-  pennsieve_doi_prefix    = var.environment_name == "prod" ? "10.26275" : "10.21397"
-  collection_namespace_id = -20
-  log_level               = var.environment_name == "prod" ? "INFO" : "DEBUG"
-  cors_allowed_origins    = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] :  ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
+  rds_db_connect_arn        = "${replace(replace(data.terraform_remote_state.pennsieve_postgres.outputs.rds_proxy_endpoint_arn, ":rds:", ":rds-db:"), ":db-proxy:", ":dbuser:")}/${var.api_postgres_user}"
+  discover_service_host     = data.terraform_remote_state.discover_service.outputs.internal_fqdn
+  pennsieve_doi_prefix      = var.environment_name == "prod" ? "10.26275" : "10.21397"
+  collections_id_space_id   = data.terraform_remote_state.discover_service.outputs.doi_collections_id_space_id
+  log_level                 = var.environment_name == "prod" ? "INFO" : "DEBUG"
+  cors_allowed_origins      = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
 }


### PR DESCRIPTION
The Discover service now exports the ID of the workspace that should be used for DOI collections publishing. This PR updates this service to use this value rather than hardcoding it in the Terraform files.