### PR TITLE
Fix import of publish bucket name

### DIFF
--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -28,7 +28,7 @@ resource "aws_lambda_function" "collections_service_api_lambda" {
       DISCOVER_SERVICE_HOST         = local.discover_service_host,
       PENNSIEVE_DOI_PREFIX          = local.pennsieve_doi_prefix,
       COLLECTIONS_ID_SPACE_ID       = local.collections_id_space_id,
-      PUBLISH_BUCKET                = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_name,
+      PUBLISH_BUCKET                = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_id,
       LOG_LEVEL                     = local.log_level
     }
   }


### PR DESCRIPTION
Fixes a Terraform error where we were using the wrong output setting for the publish bucket. The name is `_id` not `_name` which refers to the domain name.