### PR TITLE
FIX: Add collection creator/publisher to public contributors

### DIFF
--- a/internal/api/publishing/manifests.go
+++ b/internal/api/publishing/manifests.go
@@ -40,7 +40,7 @@ type ManifestV5 struct {
 	Description        string                 `json:"description"`
 	Creator            PublishedContributor   `json:"creator"`
 	Contributors       []PublishedContributor `json:"contributors"`
-	SourceOrganization string                 `json:"sourceOrganization"`
+	SourceOrganization string                 `json:"sourceOrganization,omitempty"`
 	Keywords           []string               `json:"keywords"`
 	DatePublished      apijson.Date           `json:"datePublished"`
 	License            string                 `json:"license,omitempty"`

--- a/internal/api/routes/publish_collection.go
+++ b/internal/api/routes/publish_collection.go
@@ -143,6 +143,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 		OwnerLastName:    util.SafeDeref(userResp.LastName),
 		OwnerORCID:       util.SafeDeref(userResp.ORCID),
 		CollectionNodeID: collection.NodeID,
+		Contributors:     []service.InternalContributor{toInternalContributor(userClaim.Id, userResp)},
 	}
 
 	// Initiate publish to Discover
@@ -338,4 +339,16 @@ func cleanupOnError(ctx context.Context, originalErr *apierrors.Error, cleanups 
 		cause = fmt.Errorf("%w; %s", originalErr, joined)
 	}
 	return apierrors.NewError(originalErr.UserMessage, cause, originalErr.StatusCode)
+}
+
+func toInternalContributor(userId int64, user users.GetUserResponse) service.InternalContributor {
+	return service.InternalContributor{
+		ID:            0,
+		FirstName:     util.SafeDeref(user.FirstName),
+		LastName:      util.SafeDeref(user.LastName),
+		ORCID:         util.SafeDeref(user.ORCID),
+		MiddleInitial: util.SafeDeref(user.MiddleInitial),
+		Degree:        util.SafeDeref(user.Degree),
+		UserID:        userId,
+	}
 }

--- a/internal/api/routes/publish_collection.go
+++ b/internal/api/routes/publish_collection.go
@@ -342,13 +342,13 @@ func cleanupOnError(ctx context.Context, originalErr *apierrors.Error, cleanups 
 }
 
 func toInternalContributor(userId int64, user users.GetUserResponse) service.InternalContributor {
-	return service.InternalContributor{
-		ID:            0,
-		FirstName:     util.SafeDeref(user.FirstName),
-		LastName:      util.SafeDeref(user.LastName),
-		ORCID:         util.SafeDeref(user.ORCID),
-		MiddleInitial: util.SafeDeref(user.MiddleInitial),
-		Degree:        util.SafeDeref(user.Degree),
-		UserID:        userId,
-	}
+	return service.NewInternalContributorBuilder().
+		WithFirstName(util.SafeDeref(user.FirstName)).
+		WithLastName(util.SafeDeref(user.LastName)).
+		WithORCID(util.SafeDeref(user.ORCID)).
+		WithMiddleInitial(util.SafeDeref(user.MiddleInitial)).
+		WithDegree(util.SafeDeref(user.Degree)).
+		WithUserID(userId).
+		Build()
+
 }

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -111,7 +111,23 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
 		WithGetDatasetsByDOIFunc(ctx, t, expectedDatasets.GetDatasetsByDOIFunc(t)).
-		WithPublishCollectionFunc(ctx, t, expectedCollection.PublishCollectionFunc(t, mockPublishDOICollectionResponse, apitest.VerifyPublishingUser(callingUser)),
+		WithPublishCollectionFunc(
+			ctx,
+			t,
+			expectedCollection.PublishCollectionFunc(
+				t,
+				mockPublishDOICollectionResponse,
+				apitest.VerifyPublishingUser(callingUser),
+				apitest.VerifyInternalContributors(service.InternalContributor{
+					ID:            0,
+					FirstName:     callingUser.GetFirstName(),
+					LastName:      callingUser.GetLastName(),
+					ORCID:         callingUser.GetORCIDOrEmpty(),
+					MiddleInitial: callingUser.GetMiddleInitial(),
+					Degree:        callingUser.GetDegree(),
+					UserID:        callingUser.GetID(),
+				}),
+			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,
 		).

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -109,17 +109,6 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 
 	mockFinalizeDOICollectionResponse := service.FinalizeDOICollectionPublishResponse{Status: dto.PublishSucceeded}
 
-	expectedInternalContributors := []service.InternalContributor{
-		{
-			ID:            0,
-			FirstName:     callingUser.GetFirstName(),
-			LastName:      callingUser.GetLastName(),
-			ORCID:         callingUser.GetORCIDOrEmpty(),
-			MiddleInitial: callingUser.GetMiddleInitial(),
-			Degree:        callingUser.GetDegree(),
-			UserID:        callingUser.GetID(),
-		},
-	}
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
 		WithGetDatasetsByDOIFunc(ctx, t, expectedDatasets.GetDatasetsByDOIFunc(t)).
 		WithPublishCollectionFunc(
@@ -129,7 +118,7 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 				t,
 				mockPublishDOICollectionResponse,
 				apitest.VerifyPublishingUser(callingUser),
-				apitest.VerifyInternalContributors(expectedInternalContributors...),
+				apitest.VerifyInternalContributors(apitest.InternalContributor(callingUser)),
 			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,
@@ -450,15 +439,7 @@ func testPublishSaveManifestFails(t *testing.T, expectationDB *fixtures.Expectat
 				t,
 				mockPublishDOICollectionResponse,
 				apitest.VerifyPublishingUser(callingUser),
-				apitest.VerifyInternalContributors(service.InternalContributor{
-					ID:            0,
-					FirstName:     callingUser.GetFirstName(),
-					LastName:      callingUser.GetLastName(),
-					ORCID:         callingUser.GetORCIDOrEmpty(),
-					MiddleInitial: callingUser.GetMiddleInitial(),
-					Degree:        callingUser.GetDegree(),
-					UserID:        callingUser.GetID(),
-				}),
+				apitest.VerifyInternalContributors(apitest.InternalContributor(callingUser)),
 			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,
@@ -570,15 +551,7 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 				t,
 				mockPublishDOICollectionResponse,
 				apitest.VerifyPublishingUser(callingUser),
-				apitest.VerifyInternalContributors(service.InternalContributor{
-					ID:            0,
-					FirstName:     callingUser.GetFirstName(),
-					LastName:      callingUser.GetLastName(),
-					ORCID:         callingUser.GetORCIDOrEmpty(),
-					MiddleInitial: callingUser.GetMiddleInitial(),
-					Degree:        callingUser.GetDegree(),
-					UserID:        callingUser.GetID(),
-				}),
+				apitest.VerifyInternalContributors(apitest.InternalContributor(callingUser)),
 			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,
@@ -946,15 +919,7 @@ func testHandlePublishCollectionAuthz(t *testing.T) {
 				WithPublishCollectionFunc(
 					expectedCollection.PublishCollectionFunc(t, mockPublishDOICollectionResponse,
 						apitest.VerifyPublishingUser(callingUser),
-						apitest.VerifyInternalContributors(service.InternalContributor{
-							ID:            0,
-							FirstName:     callingUser.GetFirstName(),
-							LastName:      callingUser.GetLastName(),
-							ORCID:         callingUser.GetORCIDOrEmpty(),
-							MiddleInitial: callingUser.GetMiddleInitial(),
-							Degree:        callingUser.GetDegree(),
-							UserID:        callingUser.GetID(),
-						}),
+						apitest.VerifyInternalContributors(apitest.InternalContributor(callingUser)),
 					),
 				).
 				WithFinalizeCollectionPublishFunc(

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -109,6 +109,17 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 
 	mockFinalizeDOICollectionResponse := service.FinalizeDOICollectionPublishResponse{Status: dto.PublishSucceeded}
 
+	expectedInternalContributors := []service.InternalContributor{
+		{
+			ID:            0,
+			FirstName:     callingUser.GetFirstName(),
+			LastName:      callingUser.GetLastName(),
+			ORCID:         callingUser.GetORCIDOrEmpty(),
+			MiddleInitial: callingUser.GetMiddleInitial(),
+			Degree:        callingUser.GetDegree(),
+			UserID:        callingUser.GetID(),
+		},
+	}
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
 		WithGetDatasetsByDOIFunc(ctx, t, expectedDatasets.GetDatasetsByDOIFunc(t)).
 		WithPublishCollectionFunc(
@@ -118,15 +129,7 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 				t,
 				mockPublishDOICollectionResponse,
 				apitest.VerifyPublishingUser(callingUser),
-				apitest.VerifyInternalContributors(service.InternalContributor{
-					ID:            0,
-					FirstName:     callingUser.GetFirstName(),
-					LastName:      callingUser.GetLastName(),
-					ORCID:         callingUser.GetORCIDOrEmpty(),
-					MiddleInitial: callingUser.GetMiddleInitial(),
-					Degree:        callingUser.GetDegree(),
-					UserID:        callingUser.GetID(),
-				}),
+				apitest.VerifyInternalContributors(expectedInternalContributors...),
 			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -443,7 +443,23 @@ func testPublishSaveManifestFails(t *testing.T, expectationDB *fixtures.Expectat
 
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
 		WithGetDatasetsByDOIFunc(ctx, t, expectedDatasets.GetDatasetsByDOIFunc(t)).
-		WithPublishCollectionFunc(ctx, t, expectedCollection.PublishCollectionFunc(t, mockPublishDOICollectionResponse, apitest.VerifyPublishingUser(callingUser)),
+		WithPublishCollectionFunc(
+			ctx,
+			t,
+			expectedCollection.PublishCollectionFunc(
+				t,
+				mockPublishDOICollectionResponse,
+				apitest.VerifyPublishingUser(callingUser),
+				apitest.VerifyInternalContributors(service.InternalContributor{
+					ID:            0,
+					FirstName:     callingUser.GetFirstName(),
+					LastName:      callingUser.GetLastName(),
+					ORCID:         callingUser.GetORCIDOrEmpty(),
+					MiddleInitial: callingUser.GetMiddleInitial(),
+					Degree:        callingUser.GetDegree(),
+					UserID:        callingUser.GetID(),
+				}),
+			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,
 		).
@@ -547,7 +563,23 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 	var actualFinalizeRequests []service.FinalizeDOICollectionPublishRequest
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
 		WithGetDatasetsByDOIFunc(ctx, t, expectedDatasets.GetDatasetsByDOIFunc(t)).
-		WithPublishCollectionFunc(ctx, t, expectedCollection.PublishCollectionFunc(t, mockPublishDOICollectionResponse, apitest.VerifyPublishingUser(callingUser)),
+		WithPublishCollectionFunc(
+			ctx,
+			t,
+			expectedCollection.PublishCollectionFunc(
+				t,
+				mockPublishDOICollectionResponse,
+				apitest.VerifyPublishingUser(callingUser),
+				apitest.VerifyInternalContributors(service.InternalContributor{
+					ID:            0,
+					FirstName:     callingUser.GetFirstName(),
+					LastName:      callingUser.GetLastName(),
+					ORCID:         callingUser.GetORCIDOrEmpty(),
+					MiddleInitial: callingUser.GetMiddleInitial(),
+					Degree:        callingUser.GetDegree(),
+					UserID:        callingUser.GetID(),
+				}),
+			),
 			expectedOrgServiceRole,
 			expectedDatasetServiceRole,
 		).
@@ -913,7 +945,17 @@ func testHandlePublishCollectionAuthz(t *testing.T) {
 			mockInternalDiscover := mocks.NewInternalDiscover().
 				WithPublishCollectionFunc(
 					expectedCollection.PublishCollectionFunc(t, mockPublishDOICollectionResponse,
-						apitest.VerifyPublishingUser(callingUser)),
+						apitest.VerifyPublishingUser(callingUser),
+						apitest.VerifyInternalContributors(service.InternalContributor{
+							ID:            0,
+							FirstName:     callingUser.GetFirstName(),
+							LastName:      callingUser.GetLastName(),
+							ORCID:         callingUser.GetORCIDOrEmpty(),
+							MiddleInitial: callingUser.GetMiddleInitial(),
+							Degree:        callingUser.GetDegree(),
+							UserID:        callingUser.GetID(),
+						}),
+					),
 				).
 				WithFinalizeCollectionPublishFunc(
 					expectedCollection.FinalizeCollectionPublishFunc(t, mockFinalizeDOICollectionResponse,

--- a/internal/api/service/discover_models_test.go
+++ b/internal/api/service/discover_models_test.go
@@ -51,7 +51,7 @@ func TestInternalContributorBuilder_Build(t *testing.T) {
 			WithUserID(userID).
 			Build()
 
-		assert.NotZero(t, c.ID)
+		assert.Positive(t, c.ID)
 		assert.Equal(t, first, c.FirstName)
 		assert.Equal(t, last, c.LastName)
 		assert.Equal(t, middle, c.MiddleInitial)
@@ -67,7 +67,7 @@ func TestInternalContributorBuilder_Build(t *testing.T) {
 			WithFirstName(value1).
 			WithLastName(value2).
 			Build()
-		require.NotZero(t, c1.ID)
+		require.Positive(t, c1.ID)
 
 		c2 := NewInternalContributorBuilder().
 			WithFirstName(value1).

--- a/internal/api/service/discover_models_test.go
+++ b/internal/api/service/discover_models_test.go
@@ -3,8 +3,10 @@ package service
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"math/rand/v2"
 	"testing"
 )
 
@@ -28,4 +30,63 @@ func TestPublishDOICollectionRequest_Marshal(t *testing.T) {
 		})
 
 	}
+}
+
+func TestInternalContributorBuilder_Build(t *testing.T) {
+
+	t.Run("correct values are set", func(t *testing.T) {
+		first := uuid.NewString()
+		last := uuid.NewString()
+		middle := uuid.NewString()
+		orcid := uuid.NewString()
+		degree := uuid.NewString()
+		userID := rand.Int64()
+
+		c := NewInternalContributorBuilder().
+			WithFirstName(first).
+			WithLastName(last).
+			WithMiddleInitial(middle).
+			WithORCID(orcid).
+			WithDegree(degree).
+			WithUserID(userID).
+			Build()
+
+		assert.NotZero(t, c.ID)
+		assert.Equal(t, first, c.FirstName)
+		assert.Equal(t, last, c.LastName)
+		assert.Equal(t, middle, c.MiddleInitial)
+		assert.Equal(t, orcid, c.ORCID)
+		assert.Equal(t, degree, c.Degree)
+		assert.Equal(t, userID, c.UserID)
+	})
+
+	t.Run("same values => same id, different values => different id", func(t *testing.T) {
+		value1 := uuid.NewString()
+		value2 := uuid.NewString()
+		c1 := NewInternalContributorBuilder().
+			WithFirstName(value1).
+			WithLastName(value2).
+			Build()
+		require.NotZero(t, c1.ID)
+
+		c2 := NewInternalContributorBuilder().
+			WithFirstName(value1).
+			WithLastName(value2).
+			Build()
+		assert.Equal(t, c1.ID, c2.ID)
+
+		d := NewInternalContributorBuilder().
+			WithFirstName(value2).
+			WithLastName(value1).
+			Build()
+		assert.NotEqual(t, c1.ID, d.ID)
+
+	})
+
+	t.Run("same value in different fields => different id", func(t *testing.T) {
+		value := uuid.NewString()
+		c := NewInternalContributorBuilder().WithFirstName(value).Build()
+		d := NewInternalContributorBuilder().WithLastName(value).Build()
+		assert.NotEqual(t, c.ID, d.ID)
+	})
 }

--- a/internal/test/apitest/collections_store.go
+++ b/internal/test/apitest/collections_store.go
@@ -464,10 +464,13 @@ func VerifyPublishingUser(expectedUser userstest.User) PublishDOICollectionReque
 		assert.Equal(t, expectedUser.GetNodeID(), request.OwnerNodeID)
 		assert.Equal(t, expectedUser.GetFirstName(), request.OwnerFirstName)
 		assert.Equal(t, expectedUser.GetLastName(), request.OwnerLastName)
-		if expectedUser.GetORCIDAuthorization() == nil {
-			assert.Empty(t, request.OwnerORCID)
-		} else {
-			assert.Equal(t, expectedUser.GetORCIDAuthorization().ORCID, request.OwnerORCID)
-		}
+		assert.Equal(t, expectedUser.GetORCIDOrEmpty(), request.OwnerORCID)
+	}
+}
+
+func VerifyInternalContributors(expectedContributors ...service.InternalContributor) PublishDOICollectionRequestVerification {
+	return func(t require.TestingT, request service.PublishDOICollectionRequest) {
+		test.Helper(t)
+		assert.Equal(t, expectedContributors, request.Contributors)
 	}
 }

--- a/internal/test/apitest/publishing.go
+++ b/internal/test/apitest/publishing.go
@@ -10,14 +10,10 @@ import (
 )
 
 func ToPublishedContributor(testUser userstest.User) publishing.PublishedContributor {
-	orcid := ""
-	if orcidAuth := testUser.GetORCIDAuthorization(); orcidAuth != nil {
-		orcid = orcidAuth.ORCID
-	}
 	return publishing.PublishedContributor{
 		FirstName:     testUser.GetFirstName(),
 		LastName:      testUser.GetLastName(),
-		Orcid:         orcid,
+		Orcid:         testUser.GetORCIDOrEmpty(),
 		MiddleInitial: testUser.GetMiddleInitial(),
 		Degree:        testUser.GetDegree(),
 	}

--- a/internal/test/apitest/publishing.go
+++ b/internal/test/apitest/publishing.go
@@ -3,6 +3,7 @@ package apitest
 import (
 	"github.com/google/uuid"
 	"github.com/pennsieve/collections-service/internal/api/publishing"
+	"github.com/pennsieve/collections-service/internal/api/service"
 	"github.com/pennsieve/collections-service/internal/test/userstest"
 	"github.com/stretchr/testify/require"
 	"math/rand/v2"
@@ -107,6 +108,17 @@ func RequireManifestsEqual(t require.TestingT, expected, actual publishing.Manif
 	require.Equal(t, expected.SourceOrganization, actual.SourceOrganization)
 	require.Equal(t, expected.Type, actual.Type)
 	require.Equal(t, expected.Version, actual.Version)
+}
+
+func InternalContributor(user userstest.User) service.InternalContributor {
+	return service.NewInternalContributorBuilder().
+		WithFirstName(user.GetFirstName()).
+		WithLastName(user.GetLastName()).
+		WithMiddleInitial(user.GetMiddleInitial()).
+		WithDegree(user.GetDegree()).
+		WithORCID(user.GetORCIDOrEmpty()).
+		WithUserID(user.GetID()).
+		Build()
 }
 
 var degrees = []string{

--- a/internal/test/mocks/users_store.go
+++ b/internal/test/mocks/users_store.go
@@ -36,9 +36,7 @@ func NewGetUserFunc(t require.TestingT, user userstest.User) GetUserFunc {
 			MiddleInitial: emptyStringToNil(user.GetMiddleInitial()),
 			LastName:      emptyStringToNil(user.GetLastName()),
 			Degree:        emptyStringToNil(user.GetDegree()),
-		}
-		if orcidAuth := user.GetORCIDAuthorization(); orcidAuth != nil {
-			userResponse.ORCID = &orcidAuth.ORCID
+			ORCID:         user.GetORCIDOrNil(),
 		}
 		return userResponse, nil
 	}

--- a/internal/test/userstest/users.go
+++ b/internal/test/userstest/users.go
@@ -15,6 +15,8 @@ type User interface {
 	GetFirstName() string
 	GetLastName() string
 	GetORCIDAuthorization() *users.ORCIDAuthorization
+	GetORCIDOrEmpty() string
+	GetORCIDOrNil() *string
 	GetMiddleInitial() string
 	GetDegree() string
 }
@@ -48,6 +50,14 @@ func (s SeedUser) GetLastName() string {
 
 // GetORCIDAuthorization always returns nil since as of now, no seed user has this set.
 func (s SeedUser) GetORCIDAuthorization() *users.ORCIDAuthorization {
+	return nil
+}
+
+func (s SeedUser) GetORCIDOrEmpty() string {
+	return ""
+}
+
+func (s SeedUser) GetORCIDOrNil() *string {
 	return nil
 }
 
@@ -123,6 +133,20 @@ func (t *TestUser) GetLastName() string {
 
 func (t *TestUser) GetORCIDAuthorization() *users.ORCIDAuthorization {
 	return t.ORCIDAuthorization
+}
+
+func (t *TestUser) GetORCIDOrEmpty() string {
+	if orcidAuth := t.ORCIDAuthorization; orcidAuth != nil {
+		return orcidAuth.ORCID
+	}
+	return ""
+}
+
+func (t *TestUser) GetORCIDOrNil() *string {
+	if orcidAuth := t.ORCIDAuthorization; orcidAuth != nil {
+		return &orcidAuth.ORCID
+	}
+	return nil
 }
 
 func (t *TestUser) GetMiddleInitial() string {


### PR DESCRIPTION
PR adds the publishing user, which at this point is the same as the collection owner, to the list of contributors sent to Discover when the collection is published. 

Discover requires that each contributor have an id. In research datasets this id is the id of the contributor in the publishing workspace's contributor table. We don't have such a table for collections since they exist outside of workspaces. So we use a hash of the publisher-owner's user fields. This will let the same user have the same source contributor id in Discover and if no collisions, different users will have different source contributor ids. Seems good enough for now, but probably not if we start allowing other contributors to be added to published collections.