### PR TITLE
FIX: API Lambda needs permission to delete object versions

### DIFF
--- a/internal/api/routes/publish_collection.go
+++ b/internal/api/routes/publish_collection.go
@@ -84,18 +84,11 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 			return dto.PublishCollectionResponse{}, apierrors.NewConflictError(err.Error())
 		}
 		return dto.PublishCollectionResponse{},
-			cleanupOnError(ctx,
-				apierrors.NewInternalServerError("error registering start of publish", err),
-				cleanupStatusIfExists(params.Container.CollectionsStore(), collection.ID),
-			)
+			cleanupOnError(ctx, params.Container.Logger(), apierrors.NewInternalServerError("error registering start of publish", err), cleanupStatusIfExists(params.Container.CollectionsStore(), collection.ID))
 	}
 
 	if len(collection.Description) == 0 {
-		return dto.PublishCollectionResponse{}, cleanupOnError(
-			ctx,
-			apierrors.NewBadRequestError("published description cannot be empty"),
-			cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-		)
+		return dto.PublishCollectionResponse{}, cleanupOnError(ctx, params.Container.Logger(), apierrors.NewBadRequestError("published description cannot be empty"), cleanupStatus(params.Container.CollectionsStore(), collection.ID))
 	}
 
 	pennsieveDOIs, _ := GroupByDatasource(collection.DOIs)
@@ -105,17 +98,11 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 		discoverDOIRes, err := params.Container.Discover().GetDatasetsByDOI(ctx, pennsieveDOIs)
 		if err != nil {
 			return dto.PublishCollectionResponse{},
-				cleanupOnError(ctx,
-					apierrors.NewInternalServerError("error getting DOI info from Discover", err),
-					cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-				)
+				cleanupOnError(ctx, params.Container.Logger(), apierrors.NewInternalServerError("error getting DOI info from Discover", err), cleanupStatus(params.Container.CollectionsStore(), collection.ID))
 		}
 		if len(discoverDOIRes.Unpublished) > 0 {
 			return dto.PublishCollectionResponse{},
-				cleanupOnError(ctx,
-					apierrors.NewBadRequestError(fmt.Sprintf("collection contains unpublished DOIs: %s", strings.Join(slices.Collect(maps.Keys(discoverDOIRes.Unpublished)), ", "))),
-					cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-				)
+				cleanupOnError(ctx, params.Container.Logger(), apierrors.NewBadRequestError(fmt.Sprintf("collection contains unpublished DOIs: %s", strings.Join(slices.Collect(maps.Keys(discoverDOIRes.Unpublished)), ", "))), cleanupStatus(params.Container.CollectionsStore(), collection.ID))
 		}
 
 		banners = collectBanners(pennsieveDOIs, discoverDOIRes.Published)
@@ -124,10 +111,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 	userResp, err := params.Container.UsersStore().GetUser(ctx, userClaim.Id)
 	if err != nil {
 		return dto.PublishCollectionResponse{},
-			cleanupOnError(ctx,
-				apierrors.NewInternalServerError("error getting user information", err),
-				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-			)
+			cleanupOnError(ctx, params.Container.Logger(), apierrors.NewInternalServerError("error getting user information", err), cleanupStatus(params.Container.CollectionsStore(), collection.ID))
 	}
 
 	discoverPubReq := service.PublishDOICollectionRequest{
@@ -150,18 +134,12 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 	internalDiscover, err := params.Container.InternalDiscover(ctx)
 	if err != nil {
 		return dto.PublishCollectionResponse{},
-			cleanupOnError(ctx,
-				apierrors.NewInternalServerError("error getting internal Discover dependency", err),
-				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-			)
+			cleanupOnError(ctx, params.Container.Logger(), apierrors.NewInternalServerError("error getting internal Discover dependency", err), cleanupStatus(params.Container.CollectionsStore(), collection.ID))
 	}
 	discoverPubResp, err := internalDiscover.PublishCollection(ctx, collection.ID, collection.UserRole, discoverPubReq)
 	if err != nil {
 		return dto.PublishCollectionResponse{},
-			cleanupOnError(ctx,
-				apierrors.NewInternalServerError("error publishing to Discover", err),
-				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-			)
+			cleanupOnError(ctx, params.Container.Logger(), apierrors.NewInternalServerError("error publishing to Discover", err), cleanupStatus(params.Container.CollectionsStore(), collection.ID))
 	}
 	params.Container.Logger().Info("publish started on Discover",
 		slog.Int64("publishedDatasetId", discoverPubResp.PublishedDatasetID),
@@ -187,6 +165,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 	if err != nil {
 		return dto.PublishCollectionResponse{},
 			cleanupOnError(ctx,
+				params.Container.Logger(),
 				apierrors.NewInternalServerError("error creating manifest", err),
 				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
 				finalizeDiscoverFailure(internalDiscover, discoverPubResp.PublishedDatasetID, discoverPubResp.PublishedVersion, collection),
@@ -199,6 +178,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 		return dto.PublishCollectionResponse{},
 			// assuming if this failed then there is nothing to clean up in S3
 			cleanupOnError(ctx,
+				params.Container.Logger(),
 				apierrors.NewInternalServerError("error publishing manifest", err),
 				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
 				finalizeDiscoverFailure(internalDiscover, discoverPubResp.PublishedDatasetID, discoverPubResp.PublishedVersion, collection),
@@ -222,7 +202,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 	discoverFinalizeResp, err := internalDiscover.FinalizeCollectionPublish(ctx, collection.ID, collection.NodeID, collection.UserRole, discoverFinalizeReq)
 	if err != nil {
 		return dto.PublishCollectionResponse{},
-			cleanupOnError(ctx,
+			cleanupOnError(ctx, params.Container.Logger(),
 				apierrors.NewInternalServerError("error finalizing publish with Discover", err),
 				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
 				cleanupManifest(params.Container.ManifestStore(), manifestKey, manifestS3VersionID),
@@ -238,7 +218,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 	// Mark publish as finished
 	if err := params.Container.CollectionsStore().FinishPublish(ctx, collection.ID, collectionsServiceStatus, true); err != nil {
 		return dto.PublishCollectionResponse{},
-			cleanupOnError(ctx,
+			cleanupOnError(ctx, params.Container.Logger(),
 				apierrors.NewInternalServerError("error marking publish as complete", err),
 				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
 				cleanupManifest(params.Container.ManifestStore(), manifestKey, manifestS3VersionID),
@@ -284,45 +264,72 @@ func creator(user users.GetUserResponse) publishing.PublishedContributor {
 	}
 }
 
-type cleanupFunc func(ctx context.Context) error
+type cleanupFunc func(ctx context.Context, logger *slog.Logger) error
 
 // cleanupStatus sets publishing status to failed. If a status does not already exist
 // the error will be added to the cleanup errors.
 func cleanupStatus(collectionsStore collections.Store, collectionID int64) cleanupFunc {
-	return func(ctx context.Context) error {
-		return collectionsStore.FinishPublish(ctx, collectionID, publishing.FailedStatus, true)
+	return func(ctx context.Context, logger *slog.Logger) error {
+		err := collectionsStore.FinishPublish(ctx, collectionID, publishing.FailedStatus, true)
+		// Error is taken care of by cleanupOnError. Here we just want to log that the
+		// cleanup ran successfully
+		if err == nil {
+			logger.Info("cleanup set publish status to failed")
+		}
+		return err
 	}
 }
 
 // cleanupStatusIfExists sets publishing status to failed if a status exists, otherwise does nothing
 func cleanupStatusIfExists(collectionsStore collections.Store, collectionID int64) cleanupFunc {
-	return func(ctx context.Context) error {
-		return collectionsStore.FinishPublish(ctx, collectionID, publishing.FailedStatus, false)
+	return func(ctx context.Context, logger *slog.Logger) error {
+		err := collectionsStore.FinishPublish(ctx, collectionID, publishing.FailedStatus, false)
+		// Error is taken care of by cleanupOnError. Here we just want to log that the
+		// cleanup ran successfully
+		if err == nil {
+			logger.Info("cleanup set publish status to failed if it existed")
+		}
+		return err
 	}
 }
 
 func cleanupManifest(manifestStore manifests.Store, key string, s3VersionID string) cleanupFunc {
-	return func(ctx context.Context) error {
-		return manifestStore.DeleteManifestVersion(ctx, key, s3VersionID)
+	return func(ctx context.Context, logger *slog.Logger) error {
+		err := manifestStore.DeleteManifestVersion(ctx, key, s3VersionID)
+		// Error is taken care of by cleanupOnError. Here we just want to log that the
+		// cleanup ran successfully
+		if err == nil {
+			logger.Info("cleanup deleted manifest file version",
+				slog.String("key", key),
+				slog.String("versionId", s3VersionID))
+		}
+		return err
 	}
 }
 
 func finalizeDiscoverFailure(discover service.InternalDiscover, publishedDatasetID, publishedVersion int64, collection collections.GetCollectionResponse) cleanupFunc {
-	return func(ctx context.Context) error {
+	return func(ctx context.Context, logger *slog.Logger) error {
 		request := service.FinalizeDOICollectionPublishRequest{
 			PublishedDatasetID: publishedDatasetID,
 			PublishedVersion:   publishedVersion,
 			PublishSuccess:     false,
 		}
 		_, err := discover.FinalizeCollectionPublish(ctx, collection.ID, collection.NodeID, collection.UserRole, request)
+		// Error is taken care of by cleanupOnError. Here we just want to log that the
+		// cleanup ran successfully
+		if err == nil {
+			logger.Info("cleanup finalized publication with Discover as failed",
+				slog.Int64("publishedDatasetId", publishedDatasetID),
+				slog.Int64("publishedVersion", publishedVersion))
+		}
 		return err
 	}
 }
 
-func cleanupOnError(ctx context.Context, originalErr *apierrors.Error, cleanups ...cleanupFunc) error {
+func cleanupOnError(ctx context.Context, logger *slog.Logger, originalErr *apierrors.Error, cleanups ...cleanupFunc) error {
 	var cleanupErrs []string
 	for _, cleanup := range cleanups {
-		if cleanupErr := cleanup(ctx); cleanupErr != nil {
+		if cleanupErr := cleanup(ctx, logger); cleanupErr != nil {
 			cleanupErrs = append(cleanupErrs,
 				fmt.Sprintf("in addition an error occured when running cleanup function: %s",
 					cleanupErr))

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -105,6 +105,7 @@ data "aws_iam_policy_document" "collections_service_api_iam_policy_document" {
     actions = [
       "s3:PutObject",
       "s3:DeleteObject",
+      "s3:DeleteObjectVersion",
       "s3:ListBucket",
     ]
 


### PR DESCRIPTION
If an error occurs during publish, the API Lambda needs to be able to delete a specific version of `manifest.json` but this permission was missing from the Lambda's policy. PR fixes this.

Also adds some info logging when cleanup operations run successfully.