### PR TITLE
Debugging collection publishing

### DIFF
--- a/internal/api/routes/publish_collection.go
+++ b/internal/api/routes/publish_collection.go
@@ -205,7 +205,8 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 			cleanupOnError(ctx, params.Container.Logger(),
 				apierrors.NewInternalServerError("error finalizing publish with Discover", err),
 				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-				cleanupManifest(params.Container.ManifestStore(), manifestKey, manifestS3VersionID),
+				// TODO: re-enable this
+				//cleanupManifest(params.Container.ManifestStore(), manifestKey, manifestS3VersionID),
 				finalizeDiscoverFailure(internalDiscover, discoverPubResp.PublishedDatasetID, discoverPubResp.PublishedVersion, collection),
 			)
 	}

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -536,7 +536,7 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 		Status:             dto.PublishInProgress,
 	}
 
-	s3Key := publishing.ManifestS3Key(expectedPublishedDatasetID)
+	//s3Key := publishing.ManifestS3Key(expectedPublishedDatasetID)
 
 	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
@@ -599,7 +599,8 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 
 	expectationDB.RequirePublishStatus(ctx, t, expectedPublishStatus)
 
-	minio.RequireNoObject(ctx, t, publishBucket, s3Key)
+	//TODO re-enable this
+	//minio.RequireNoObject(ctx, t, publishBucket, s3Key)
 
 	require.Len(t, actualFinalizeRequests, 2)
 	assert.True(t, actualFinalizeRequests[0].PublishSuccess)

--- a/internal/api/store/manifests/manifests.go
+++ b/internal/api/store/manifests/manifests.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pennsieve/collections-service/internal/api/publishing"
 	"log/slog"
+	"time"
 )
 
 type Store interface {
@@ -46,7 +47,16 @@ func (s *S3Store) SaveManifest(ctx context.Context, key string, manifest publish
 	if err != nil {
 		return SaveManifestResponse{}, fmt.Errorf("error writing manifest to %s/%s: %w", s.publishBucket, key, err)
 	}
-	return SaveManifestResponse{S3VersionID: aws.ToString(putOut.VersionId)}, err
+	versionId := aws.ToString(putOut.VersionId)
+	s.logger.Debug("wrote manifest",
+		slog.String("logSource", "S3Store"),
+		slog.String("bucket", s.publishBucket),
+		slog.String("key", key),
+		slog.String("s3VersionId", versionId),
+	)
+	//TODO Remove this!
+	time.Sleep(time.Second)
+	return SaveManifestResponse{S3VersionID: versionId}, nil
 }
 
 func (s *S3Store) DeleteManifestVersion(ctx context.Context, key string, s3VersionID string) error {


### PR DESCRIPTION
Publish is failing when calling discover-service's DOI collection finalize because it cannot find the manifest we write to S3. Adding some debugging to check the bucket and key we are using to write the manifest.

Also adds some temporary changes to keep the manifest around instead of deleting it when finalize fails.