### PR TITLE
FIX: manifest must include sourceOrganization

### DIFF
--- a/internal/api/config/pennsieve_test.go
+++ b/internal/api/config/pennsieve_test.go
@@ -15,11 +15,13 @@ func TestPennsieveConfig_Load(t *testing.T) {
 	expectedDiscoverHost := uuid.NewString()
 	expectedPennsieveDOIPrefix := uuid.NewString()
 	expectedCollectionsIDSpaceID := apitest.CollectionsIDSpaceID
+	expectedCollectionsIDSpaceName := apitest.CollectionsIDSpaceName
 	expectedPublishBucket := uuid.NewString()
 
 	t.Setenv(config.DiscoverServiceHostKey, expectedDiscoverHost)
 	t.Setenv(config.PennsieveDOIPrefixKey, expectedPennsieveDOIPrefix)
 	t.Setenv(config.CollectionsIDSpaceIDKey, strconv.FormatInt(expectedCollectionsIDSpaceID, 10))
+	t.Setenv(config.CollectionsIDSpaceNameKey, expectedCollectionsIDSpaceName)
 	t.Setenv(config.PublishBucketKey, expectedPublishBucket)
 
 	expectedEnvironment := uuid.NewString()
@@ -28,7 +30,8 @@ func TestPennsieveConfig_Load(t *testing.T) {
 
 	assert.Equal(t, fmt.Sprintf("https://%s", expectedDiscoverHost), actualConfig.DiscoverServiceURL)
 	assert.Equal(t, expectedPennsieveDOIPrefix, actualConfig.DOIPrefix)
-	assert.Equal(t, expectedCollectionsIDSpaceID, actualConfig.CollectionsIDSpaceID)
+	assert.Equal(t, expectedCollectionsIDSpaceID, actualConfig.CollectionsIDSpace.ID)
+	assert.Equal(t, expectedCollectionsIDSpaceName, actualConfig.CollectionsIDSpace.Name)
 	assert.Equal(t, expectedPublishBucket, actualConfig.PublishBucket)
 
 	assert.NotNil(t, actualConfig.JWTSecretKey)

--- a/internal/api/config/pennsieveenv.go
+++ b/internal/api/config/pennsieveenv.go
@@ -5,25 +5,28 @@ import sharedconfig "github.com/pennsieve/collections-service/internal/shared/co
 const DiscoverServiceHostKey = "DISCOVER_SERVICE_HOST"
 const PennsieveDOIPrefixKey = "PENNSIEVE_DOI_PREFIX"
 const CollectionsIDSpaceIDKey = "COLLECTIONS_ID_SPACE_ID"
+const CollectionsIDSpaceNameKey = "COLLECTIONS_ID_SPACE_NAME"
 const PublishBucketKey = "PUBLISH_BUCKET"
 
 const ServiceName = "collections-service"
 const JWTSecretKeySSMName = "jwt-secret-key"
 
 type PennsieveSettings struct {
-	DiscoverServiceHost  sharedconfig.EnvironmentSetting
-	DOIPrefix            sharedconfig.EnvironmentSetting
-	CollectionsIDSpaceID sharedconfig.EnvironmentSetting
-	PublishBucket        sharedconfig.EnvironmentSetting
-	JWTSecretKey         *sharedconfig.SSMSetting
+	DiscoverServiceHost    sharedconfig.EnvironmentSetting
+	DOIPrefix              sharedconfig.EnvironmentSetting
+	CollectionsIDSpaceID   sharedconfig.EnvironmentSetting
+	CollectionsIDSpaceName sharedconfig.EnvironmentSetting
+	PublishBucket          sharedconfig.EnvironmentSetting
+	JWTSecretKey           *sharedconfig.SSMSetting
 }
 
 var DeployedPennsieveSettings = PennsieveSettings{
-	DiscoverServiceHost:  sharedconfig.NewEnvironmentSetting(DiscoverServiceHostKey),
-	DOIPrefix:            sharedconfig.NewEnvironmentSetting(PennsieveDOIPrefixKey),
-	CollectionsIDSpaceID: sharedconfig.NewEnvironmentSetting(CollectionsIDSpaceIDKey),
-	PublishBucket:        sharedconfig.NewEnvironmentSetting(PublishBucketKey),
-	JWTSecretKey:         NewJWTSecretKeySetting(),
+	DiscoverServiceHost:    sharedconfig.NewEnvironmentSetting(DiscoverServiceHostKey),
+	DOIPrefix:              sharedconfig.NewEnvironmentSetting(PennsieveDOIPrefixKey),
+	CollectionsIDSpaceID:   sharedconfig.NewEnvironmentSetting(CollectionsIDSpaceIDKey),
+	CollectionsIDSpaceName: sharedconfig.NewEnvironmentSetting(CollectionsIDSpaceNameKey),
+	PublishBucket:          sharedconfig.NewEnvironmentSetting(PublishBucketKey),
+	JWTSecretKey:           NewJWTSecretKeySetting(),
 }
 
 func NewJWTSecretKeySetting() *sharedconfig.SSMSetting {

--- a/internal/api/container/container.go
+++ b/internal/api/container/container.go
@@ -149,7 +149,7 @@ func (c *Container) InternalDiscover(ctx context.Context) (service.InternalDisco
 		c.internalDiscover = service.NewHTTPInternalDiscover(
 			c.Config.PennsieveConfig.DiscoverServiceURL,
 			jwtSecretKey,
-			c.Config.PennsieveConfig.CollectionsIDSpaceID,
+			c.Config.PennsieveConfig.CollectionsIDSpace.ID,
 			c.Logger())
 	}
 	return c.internalDiscover, nil

--- a/internal/api/handler.go
+++ b/internal/api/handler.go
@@ -46,9 +46,12 @@ func CollectionsServiceAPIHandler(
 			slog.Group("pennsieve",
 				slog.String("doiPrefix", config.PennsieveConfig.DOIPrefix),
 				slog.String("discoverURL", config.PennsieveConfig.DiscoverServiceURL),
-				slog.Int64("collectionsIDSpaceID", config.PennsieveConfig.CollectionsIDSpaceID),
 				slog.String("jwtSecretKey", config.PennsieveConfig.JWTSecretKey.String()),
 				slog.String("publishBucket", config.PennsieveConfig.PublishBucket),
+				slog.Group("collectionsIDSpace",
+					slog.Int64("id", config.PennsieveConfig.CollectionsIDSpace.ID),
+					slog.String("name", config.PennsieveConfig.CollectionsIDSpace.Name),
+				),
 			),
 		)
 

--- a/internal/api/publishing/manifests.go
+++ b/internal/api/publishing/manifests.go
@@ -40,7 +40,7 @@ type ManifestV5 struct {
 	Description        string                 `json:"description"`
 	Creator            PublishedContributor   `json:"creator"`
 	Contributors       []PublishedContributor `json:"contributors"`
-	SourceOrganization string                 `json:"sourceOrganization,omitempty"`
+	SourceOrganization string                 `json:"sourceOrganization"`
 	Keywords           []string               `json:"keywords"`
 	DatePublished      apijson.Date           `json:"datePublished"`
 	License            string                 `json:"license,omitempty"`
@@ -158,6 +158,11 @@ func (b *ManifestBuilder) WithID(doi string) *ManifestBuilder {
 
 func (b *ManifestBuilder) WithReferences(dois []string) *ManifestBuilder {
 	b.m.References.IDs = append(b.m.References.IDs, dois...)
+	return b
+}
+
+func (b *ManifestBuilder) WithSourceOrganization(sourceOrg string) *ManifestBuilder {
+	b.m.SourceOrganization = sourceOrg
 	return b
 }
 

--- a/internal/api/routes/publish_collection.go
+++ b/internal/api/routes/publish_collection.go
@@ -161,6 +161,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 		WithLicense(publishRequest.License).
 		WithKeywords(publishRequest.Tags).
 		WithReferences(pennsieveDOIs).
+		WithSourceOrganization(params.Config.PennsieveConfig.CollectionsIDSpace.Name).
 		Build()
 	if err != nil {
 		return dto.PublishCollectionResponse{},
@@ -205,8 +206,7 @@ func PublishCollection(ctx context.Context, params Params) (dto.PublishCollectio
 			cleanupOnError(ctx, params.Container.Logger(),
 				apierrors.NewInternalServerError("error finalizing publish with Discover", err),
 				cleanupStatus(params.Container.CollectionsStore(), collection.ID),
-				// TODO: re-enable this
-				//cleanupManifest(params.Container.ManifestStore(), manifestKey, manifestS3VersionID),
+				cleanupManifest(params.Container.ManifestStore(), manifestKey, manifestS3VersionID),
 				finalizeDiscoverFailure(internalDiscover, discoverPubResp.PublishedDatasetID, discoverPubResp.PublishedVersion, collection),
 			)
 	}

--- a/internal/api/routes/publish_collection_test.go
+++ b/internal/api/routes/publish_collection_test.go
@@ -104,7 +104,7 @@ func testPublish(t *testing.T, expectationDB *fixtures.ExpectationDB, minio *fix
 		Status:             expectedDiscoverPublishStatus,
 	}
 
-	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
+	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpace.ID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
 
 	mockFinalizeDOICollectionResponse := service.FinalizeDOICollectionPublishResponse{Status: dto.PublishSucceeded}
@@ -427,7 +427,7 @@ func testPublishSaveManifestFails(t *testing.T, expectationDB *fixtures.Expectat
 		Status:             expectedDiscoverPublishStatus,
 	}
 
-	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
+	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpace.ID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
 
 	mockDiscoverMux := mocks.NewDiscoverMux(*pennsieveConfig.JWTSecretKey.Value).
@@ -536,9 +536,9 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 		Status:             dto.PublishInProgress,
 	}
 
-	//s3Key := publishing.ManifestS3Key(expectedPublishedDatasetID)
+	s3Key := publishing.ManifestS3Key(expectedPublishedDatasetID)
 
-	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpaceID)
+	expectedOrgServiceRole := apitest.ExpectedOrgServiceRole(pennsieveConfig.CollectionsIDSpace.ID)
 	expectedDatasetServiceRole := expectedCollection.DatasetServiceRole(role.Owner)
 
 	var actualFinalizeRequests []service.FinalizeDOICollectionPublishRequest
@@ -599,8 +599,7 @@ func testPublishFinalizeFails(t *testing.T, expectationDB *fixtures.ExpectationD
 
 	expectationDB.RequirePublishStatus(ctx, t, expectedPublishStatus)
 
-	//TODO re-enable this
-	//minio.RequireNoObject(ctx, t, publishBucket, s3Key)
+	minio.RequireNoObject(ctx, t, publishBucket, s3Key)
 
 	require.Len(t, actualFinalizeRequests, 2)
 	assert.True(t, actualFinalizeRequests[0].PublishSuccess)

--- a/internal/api/store/manifests/manifests.go
+++ b/internal/api/store/manifests/manifests.go
@@ -8,7 +8,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/pennsieve/collections-service/internal/api/publishing"
 	"log/slog"
-	"time"
 )
 
 type Store interface {
@@ -54,8 +53,6 @@ func (s *S3Store) SaveManifest(ctx context.Context, key string, manifest publish
 		slog.String("key", key),
 		slog.String("s3VersionId", versionId),
 	)
-	//TODO Remove this!
-	time.Sleep(time.Second)
 	return SaveManifestResponse{S3VersionID: versionId}, nil
 }
 

--- a/internal/test/apitest/config.go
+++ b/internal/test/apitest/config.go
@@ -10,6 +10,7 @@ import (
 )
 
 const CollectionsIDSpaceID = int64(-20)
+const CollectionsIDSpaceName = "Test Collections Publishing"
 const PublishBucket = "test-publish-bucket"
 
 type ConfigBuilder struct {
@@ -46,7 +47,7 @@ func PennsieveConfigWithOptions(opts ...config.PennsieveOption) config.Pennsieve
 		config.WithDiscoverServiceURL("http://example.com/discover"),
 		config.WithDOIPrefix(PennsieveDOIPrefix),
 		config.WithJWTSecretKey(uuid.NewString()),
-		config.WithCollectionsIDSpaceID(CollectionsIDSpaceID),
+		config.WithCollectionsIDSpace(CollectionsIDSpaceID, CollectionsIDSpaceName),
 		config.WithPublishBucket(PublishBucket),
 	)
 	for _, opt := range opts {

--- a/internal/test/apitest/container.go
+++ b/internal/test/apitest/container.go
@@ -122,7 +122,7 @@ func (c *TestContainer) WithHTTPTestInternalDiscover(pennsieveConfig config.Penn
 	c.TestInternalDiscover = service.NewHTTPInternalDiscover(
 		pennsieveConfig.DiscoverServiceURL,
 		*pennsieveConfig.JWTSecretKey.Value,
-		pennsieveConfig.CollectionsIDSpaceID,
+		pennsieveConfig.CollectionsIDSpace.ID,
 		c.Logger())
 	return c
 }

--- a/internal/test/apitest/publishing.go
+++ b/internal/test/apitest/publishing.go
@@ -74,7 +74,8 @@ func NewExpectedManifest(t require.TestingT, opts ...ManifestOption) publishing.
 				userstest.WithDegree(degrees[rand.IntN(len(degrees))]),
 				userstest.WithMiddleInitial(uuid.NewString()[:1]),
 				userstest.WithORCID(uuid.NewString()),
-			)))
+			))).
+		WithSourceOrganization(CollectionsIDSpaceName)
 	for _, opt := range opts {
 		builder = opt(builder)
 	}
@@ -108,6 +109,7 @@ func RequireManifestsEqual(t require.TestingT, expected, actual publishing.Manif
 	require.Equal(t, expected.SourceOrganization, actual.SourceOrganization)
 	require.Equal(t, expected.Type, actual.Type)
 	require.Equal(t, expected.Version, actual.Version)
+	require.Equal(t, expected.SourceOrganization, actual.SourceOrganization)
 }
 
 func InternalContributor(user userstest.User) service.InternalContributor {

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -28,6 +28,7 @@ resource "aws_lambda_function" "collections_service_api_lambda" {
       DISCOVER_SERVICE_HOST         = local.discover_service_host,
       PENNSIEVE_DOI_PREFIX          = local.pennsieve_doi_prefix,
       COLLECTIONS_ID_SPACE_ID       = local.collections_id_space_id,
+      COLLECTIONS_ID_SPACE_NAME     = local.collections_id_space_name,
       PUBLISH_BUCKET                = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish50_bucket_id,
       LOG_LEVEL                     = local.log_level
     }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -38,6 +38,7 @@ locals {
   discover_service_host     = data.terraform_remote_state.discover_service.outputs.internal_fqdn
   pennsieve_doi_prefix      = var.environment_name == "prod" ? "10.26275" : "10.21397"
   collections_id_space_id   = data.terraform_remote_state.discover_service.outputs.doi_collections_id_space_id
+  collections_id_space_name = data.terraform_remote_state.discover_service.outputs.doi_collections_id_space_name
   log_level                 = var.environment_name == "prod" ? "INFO" : "DEBUG"
   cors_allowed_origins      = var.environment_name == "prod" ? ["https://discover.pennsieve.io", "https://app.pennsieve.io"] : ["http://localhost:3000", "https://discover.pennsieve.net", "https://app.pennsieve.net"]
 }


### PR DESCRIPTION
PR #41 changed the JSON serialization of manifest files to omit `sourceOrganization` if the field was empty. This broke de-serialization on the discover-service side.

This PR removes `omitEmpty` from the `sourceOrganzation` json struct tag. Also reads the collections publishing workspace name from discover-service Terraform outputs for use as the value of `sourceOrganization` in manifests.