### PR TITLE
Always query Discover if includePublishedDataset is true

### DIFF
--- a/internal/api/routes/get_collection.go
+++ b/internal/api/routes/get_collection.go
@@ -45,7 +45,7 @@ func GetCollection(ctx context.Context, params Params) (dto.GetCollectionRespons
 	}
 
 	var datasetPublishStatusResp *service.DatasetPublishStatusResponse
-	if includePublishedDataset && storeResp.Publication != nil {
+	if includePublishedDataset {
 		datasetPublishStatusResp, err = params.getDatasetPublishStatus(ctx, storeResp.ID, nodeID, storeResp.UserRole)
 		if err != nil {
 			return dto.GetCollectionResponse{}, err

--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -26,12 +26,19 @@ func assertEqualExpectedPublishStatus(t *testing.T, expected collections.Publish
 	assert.Equal(t, expected.Type, actual.Publication.Type)
 }
 
-func assertDraftPublication(t *testing.T, actual dto.CollectionSummary) {
+func assertDraftPublication(t *testing.T, actual dto.CollectionSummary, expectPublishedDataset bool) {
 	t.Helper()
-	assert.NotNil(t, actual.Publication)
+	require.NotNil(t, actual.Publication)
 	assert.Equal(t, publishing.DraftStatus, actual.Publication.Status)
 	assert.Empty(t, actual.Publication.Type)
-	assert.Nil(t, actual.Publication.PublishedDataset)
+	if expectPublishedDataset {
+		require.NotNil(t, actual.Publication.PublishedDataset)
+		assert.Zero(t, actual.Publication.PublishedDataset.Version)
+		assert.Zero(t, actual.Publication.PublishedDataset.ID)
+		assert.Nil(t, actual.Publication.PublishedDataset.LastPublishedDate)
+	} else {
+		assert.Nil(t, actual.Publication.PublishedDataset)
+	}
 }
 
 func assertEqualExpectedCollectionSummary(t *testing.T, expected *apitest.ExpectedCollection, actual dto.CollectionSummary, expectedDatasets *apitest.ExpectedPennsieveDatasets) {


### PR DESCRIPTION
PR #45 didn't bother querying Discover if the local state indicated that the dataset has not been published even when `includePublishedDataset=true`. 

This PR changes this so that the caller can rely on `publication.publishedDataset` being present in the response if they requested `includePublishedDataset`