### PR TITLE
Do not allow deletion of published collections

### DIFF
--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -50,7 +50,7 @@ func assertEqualExpectedCollectionSummary(t *testing.T, expected *apitest.Expect
 	assert.Len(t, expected.DOIs, actual.Size)
 	bannerLen := min(config.MaxBannersPerCollection, len(expected.DOIs))
 	expectedBanners := expectedDatasets.ExpectedBannersForDOIs(t, expected.DOIs.Strings()[:bannerLen])
-	assert.Equal(t, expectedBanners, actual.Banners)
+	assert.ElementsMatch(t, expectedBanners, actual.Banners)
 }
 
 // assertEqualExpectedGetCollectionResponse makes a number of simplifying assumptions:


### PR DESCRIPTION
PR updates the delete route so that published collections can no longer be deleted. 

Delete is only allowed if there is no publish history in the `publish_status` table or if there is a completed removal for the collection in that table. That is, if the collection has never been published or if it has been unpublished.

Any other situation results in a 409 Conflict error response.