### PR TITLE
Return publication info in GET / response.

### DIFF
--- a/internal/api/dto/collection.go
+++ b/internal/api/dto/collection.go
@@ -100,6 +100,8 @@ func (r GetCollectionResponse) MarshalJSON() ([]byte, error) {
 	})
 }
 
+// PublishedDataset contains publishing info obtained from Discover.
+// Only included in responses to requests that use the includePublishedDataset query param
 type PublishedDataset struct {
 	ID                int32      `json:"id,omitempty"`
 	Version           int32      `json:"version"`
@@ -113,7 +115,7 @@ type Publication struct {
 }
 
 // CollectionSummary is a base struct shared by POST /,  GET /,  GET /{nodeId}, and PATCH /{nodeId} responses.
-// Publication is never returned by POST / or GET /
+// Publication is never returned by POST /
 type CollectionSummary struct {
 	NodeID      string       `json:"nodeId"`
 	Name        string       `json:"name"`

--- a/internal/api/routes/get_collections.go
+++ b/internal/api/routes/get_collections.go
@@ -67,6 +67,7 @@ func GetCollections(ctx context.Context, params Params) (dto.GetCollectionsRespo
 			Banners:     collectBanners(storeCollection.BannerDOIs, doiToPublicDataset),
 			Size:        storeCollection.Size,
 			UserRole:    storeCollection.UserRole.String(),
+			Publication: ToDTOPublication(storeCollection.Publication, nil),
 		}
 		response.Collections = append(response.Collections, collectionDTO)
 	}

--- a/internal/api/routes/get_collections_test.go
+++ b/internal/api/routes/get_collections_test.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pennsieve/collections-service/internal/api/store/collections"
 	"github.com/pennsieve/collections-service/internal/test"
 	"github.com/pennsieve/collections-service/internal/test/apitest"
+	"github.com/pennsieve/collections-service/internal/test/apitest/builders/stores/collectionstest"
 	"github.com/pennsieve/collections-service/internal/test/fixtures"
 	"github.com/pennsieve/collections-service/internal/test/mocks"
 	"github.com/pennsieve/collections-service/internal/test/userstest"
@@ -101,6 +102,9 @@ func testGetCollections(t *testing.T, expectationDB *fixtures.ExpectationDB) {
 		WithPublicDatasets(expectedDatasets.NewPublished())
 	expectationDB.CreateCollection(ctx, t, user1CollectionOneDOI)
 
+	user1CollectionOneDOIPublishStatus := collectionstest.NewCompletedPublishStatus(*user1CollectionOneDOI.ID, *user1.ID)
+	expectationDB.CreatePublishStatus(ctx, t, user1CollectionOneDOIPublishStatus)
+
 	user1CollectionFiveDOI := apitest.NewExpectedCollection().WithNodeID().WithUser(*user1.ID, pgdb.Owner).
 		WithPublicDatasets(expectedDatasets.NewPublished(), expectedDatasets.NewPublished(), expectedDatasets.NewPublished(), expectedDatasets.NewPublished(), expectedDatasets.NewPublished())
 	expectationDB.CreateCollection(ctx, t, user1CollectionFiveDOI)
@@ -148,12 +152,15 @@ func testGetCollections(t *testing.T, expectationDB *fixtures.ExpectationDB) {
 	// They should be returned in oldest first order
 	actualCollection1 := response.Collections[0]
 	assertEqualExpectedCollectionSummary(t, user1CollectionNoDOI, actualCollection1, expectedDatasets)
+	assertDraftPublication(t, actualCollection1, false)
 
 	actualCollection2 := response.Collections[1]
 	assertEqualExpectedCollectionSummary(t, user1CollectionOneDOI, actualCollection2, expectedDatasets)
+	assertEqualExpectedPublishStatus(t, user1CollectionOneDOIPublishStatus, actualCollection2)
 
 	actualCollection3 := response.Collections[2]
 	assertEqualExpectedCollectionSummary(t, user1CollectionFiveDOI, actualCollection3, expectedDatasets)
+	assertDraftPublication(t, actualCollection3, false)
 
 	// try user2's collections
 	user2Claims := apitest.DefaultClaims(user2)

--- a/internal/api/routes/mapping.go
+++ b/internal/api/routes/mapping.go
@@ -10,15 +10,25 @@ import (
 	"github.com/pennsieve/collections-service/internal/api/store/collections"
 )
 
-func discoverToDTOPublishedDataset(fromDiscover *service.DatasetPublishStatusResponse) *dto.PublishedDataset {
-	if fromDiscover == nil {
-		return nil
+func ToDTOPublication(storePublication *collections.Publication, fromDiscover *service.DatasetPublishStatusResponse) *dto.Publication {
+	publication := dto.Publication{}
+
+	if fromDiscover != nil {
+		publication.PublishedDataset = &dto.PublishedDataset{
+			ID:                fromDiscover.PublishedDatasetID,
+			Version:           fromDiscover.PublishedVersionCount,
+			LastPublishedDate: fromDiscover.LastPublishedDate,
+		}
 	}
-	return &dto.PublishedDataset{
-		ID:                fromDiscover.PublishedDatasetID,
-		Version:           fromDiscover.PublishedVersionCount,
-		LastPublishedDate: fromDiscover.LastPublishedDate,
+
+	if storePublication != nil {
+		publication.Status = storePublication.Status
+		publication.Type = storePublication.Type
+	} else {
+		publication.Status = publishing.DraftStatus
 	}
+
+	return &publication
 }
 
 func (p Params) StoreToDTOCollection(ctx context.Context, storeCollection collections.GetCollectionResponse, datasetPublishStatus *service.DatasetPublishStatusResponse) (dto.GetCollectionResponse, error) {
@@ -29,9 +39,7 @@ func (p Params) StoreToDTOCollection(ctx context.Context, storeCollection collec
 			Description: storeCollection.Description,
 			Size:        storeCollection.Size,
 			UserRole:    storeCollection.UserRole.String(),
-			Publication: &dto.Publication{
-				PublishedDataset: discoverToDTOPublishedDataset(datasetPublishStatus),
-			},
+			Publication: ToDTOPublication(storeCollection.Publication, datasetPublishStatus),
 		},
 	}
 	if publication := storeCollection.Publication; publication != nil {

--- a/internal/api/store/collections/collections_test.go
+++ b/internal/api/store/collections/collections_test.go
@@ -179,8 +179,12 @@ func testGetCollections(t *testing.T, store *collections.PostgresStore, expectat
 
 	user1CollectionNoDOI := apitest.NewExpectedCollection().WithNodeID().WithUser(*user1.ID, pgdb.Owner)
 	expectationDB.CreateCollection(ctx, t, user1CollectionNoDOI)
+
 	user1CollectionOneDOI := apitest.NewExpectedCollection().WithNodeID().WithUser(*user1.ID, pgdb.Owner).WithDOIs(apitest.NewPennsieveDOI())
 	expectationDB.CreateCollection(ctx, t, user1CollectionOneDOI)
+	user1CollectionOneDOIPublishStatus := collectionstest.NewCompletedPublishStatus(*user1CollectionOneDOI.ID, *user1.ID)
+	expectationDB.CreatePublishStatus(ctx, t, user1CollectionOneDOIPublishStatus)
+
 	user1CollectionFiveDOI := apitest.NewExpectedCollection().WithNodeID().WithUser(*user1.ID, pgdb.Owner).WithDOIs(apitest.NewPennsieveDOI(), apitest.NewPennsieveDOI(), apitest.NewPennsieveDOI(), apitest.NewPennsieveDOI(), apitest.NewPennsieveDOI())
 	expectationDB.CreateCollection(ctx, t, user1CollectionFiveDOI)
 
@@ -201,12 +205,15 @@ func testGetCollections(t *testing.T, store *collections.PostgresStore, expectat
 	// They should be returned in oldest first order
 	actualCollection1 := response.Collections[0]
 	assertExpectedEqualCollectionSummary(t, user1CollectionNoDOI, actualCollection1)
+	assert.Nil(t, actualCollection1.Publication)
 
 	actualCollection2 := response.Collections[1]
 	assertExpectedEqualCollectionSummary(t, user1CollectionOneDOI, actualCollection2)
+	assertExpectedPublishStatusEqual(t, user1CollectionOneDOIPublishStatus, actualCollection2.CollectionBase)
 
 	actualCollection3 := response.Collections[2]
 	assertExpectedEqualCollectionSummary(t, user1CollectionFiveDOI, actualCollection3)
+	assert.Nil(t, actualCollection3.Publication)
 
 	// try user2's collections
 	user2CollectionResp, err := store.GetCollections(ctx, *user2.ID, limit, offset)


### PR DESCRIPTION
Updates the response to Get Collections to include the same `publication` field and value as Get Collection for each collection returned. Except that we don't support `includePublishedDatasets=true` query param for `GET /` yet, so no `publishedDataset` field in those `publication`s.