### PR TITLE
868g9upnw upgrade pennsieve-go-core v1.13.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/pennsieve/dbmigrate-go v1.1.1
-	github.com/pennsieve/pennsieve-go-core v1.13.5
+	github.com/pennsieve/pennsieve-go-core v1.13.7
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0
 )

--- a/go.sum
+++ b/go.sum
@@ -144,8 +144,8 @@ github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJw
 github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pennsieve/dbmigrate-go v1.1.1 h1:2ioD6WXfzbMLp0f6cSgksc34Zkp7FzPgG6EFLsRbZ/0=
 github.com/pennsieve/dbmigrate-go v1.1.1/go.mod h1:q1DUCrXZkoGhBaRtTSkQSr8nu22xIB5IqSH7sOa5+f0=
-github.com/pennsieve/pennsieve-go-core v1.13.5 h1:sLNA4cXCoIWIkkjk8m4iYc9LqOK/C0CEWeVJjzOp1Ts=
-github.com/pennsieve/pennsieve-go-core v1.13.5/go.mod h1:MeMDPuGOXkY8q+opOES8r7ib3EAt5dveB+PMjgtLNKM=
+github.com/pennsieve/pennsieve-go-core v1.13.7 h1:chscmBoATCkqvWakkcbvvia4Vx1WnwDe7wXboL4Huq4=
+github.com/pennsieve/pennsieve-go-core v1.13.7/go.mod h1:MeMDPuGOXkY8q+opOES8r7ib3EAt5dveB+PMjgtLNKM=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Description
**ClickUp Ticket:** [868g9upnw](https://app.clickup.com/t/868g9upnw)
**Related PR:** https://github.com/Pennsieve/pennsieve-go-core/pull/45